### PR TITLE
fix: incremental fetch, advanced stat precision, rankings API response key #26

### DIFF
--- a/backend/scripts/derive_team_stats.py
+++ b/backend/scripts/derive_team_stats.py
@@ -77,13 +77,13 @@ def derive_team_stats():
             ROUND(AVG(COALESCE(stl, 0))::numeric, 1) as stl_avg,
             ROUND(AVG(COALESCE(blk, 0))::numeric, 1) as blk_avg,
             ROUND(AVG(COALESCE(pts, 0))::numeric, 1) as pts_avg,
-            ROUND(AVG(COALESCE(orb_pct, 0))::numeric, 1) as orb_pct,
-            ROUND(AVG(COALESCE(drb_pct, 0))::numeric, 1) as drb_pct,
-            ROUND(AVG(COALESCE(trb_pct, 0))::numeric, 1) as trb_pct,
-            ROUND(AVG(COALESCE(ast_pct, 0))::numeric, 1) as ast_pct,
+            ROUND(AVG(COALESCE(orb_pct, 0))::numeric, 4) as orb_pct,
+            ROUND(AVG(COALESCE(drb_pct, 0))::numeric, 4) as drb_pct,
+            ROUND(AVG(COALESCE(trb_pct, 0))::numeric, 4) as trb_pct,
+            ROUND(AVG(COALESCE(ast_pct, 0))::numeric, 4) as ast_pct,
             ROUND(AVG(COALESCE(tov_pct, 0))::numeric, 1) as tov_pct,
-            ROUND(AVG(COALESCE(usg_pct, 0))::numeric, 1) as usg_pct,
-            ROUND(AVG(COALESCE(ts_pct, 0))::numeric, 1) as ts_pct
+            ROUND(AVG(COALESCE(usg_pct, 0))::numeric, 4) as usg_pct,
+            ROUND(AVG(COALESCE(ts_pct, 0))::numeric, 4) as ts_pct
         FROM game_stats
         GROUP BY team_id, season
         ON CONFLICT (team_id, season) DO UPDATE SET

--- a/backend/scripts/fetch_nba_stats.py
+++ b/backend/scripts/fetch_nba_stats.py
@@ -299,7 +299,7 @@ def extract_team_stats(game_id, game_date, team_mapping):
                             'reboundPercentage': 'TRB_PCT',
                             'assistPercentage': 'AST_PCT',
                             'estimatedTeamTurnoverPercentage': 'TOV_PCT',
-                            'usagePercentage': 'USG_PCT',
+                            'estimatedUsagePercentage': 'USG_PCT',  # Changed from 'usagePercentage' (always 1.0) to 'estimatedUsagePercentage' (actual values)
                             'trueShootingPercentage': 'TS_PCT',
                         }
                         
@@ -567,9 +567,6 @@ def main():
         print("❌ No games found")
         conn.close()
         return
-    
-    # Clear old season data for fresh load
-    clear_season_data(conn, season)
     
     # Record all games for audit trail (uses real API data from LeagueGameLog)
     record_games(conn, game_details, season)

--- a/backend/src/routes/rankings.js
+++ b/backend/src/routes/rankings.js
@@ -70,7 +70,7 @@ router.get("/rankings", async (req, res) => {
 
     res.json({
       success: true,
-      data: result.rows,
+      rankings: result.rows,
       category,
       label: result.label,
       cached: result.cached,

--- a/backend/src/services/rankingsService.js
+++ b/backend/src/services/rankingsService.js
@@ -1,9 +1,9 @@
 const { STAT_CATEGORIES } = require("./statProcessor");
 
 function getCategories() {
-  return Object.entries(STAT_CATEGORIES).map(([key, value]) => ({
-    code: key,
-    label: value.label,
+  return Object.entries(STAT_CATEGORIES).map(([code, config]) => ({
+    code,
+    label: config.label,
   }));
 }
 

--- a/backend/src/services/teamsService.js
+++ b/backend/src/services/teamsService.js
@@ -11,7 +11,8 @@ async function getTeamStats(teamId, season, db) {
       ts.oreb, ts.dreb, ts.reb,
       ts.ast, ts.tov, ts.stl, ts.blk, ts.pf, ts.pts,
       ts.fg_avg, ts.fga_avg, ts.three_p_avg,
-      ts.reb_avg, ts.ast_avg, ts.tov_avg, ts.stl_avg, ts.blk_avg, ts.pts_avg
+      ts.reb_avg, ts.ast_avg, ts.tov_avg, ts.stl_avg, ts.blk_avg, ts.pts_avg,
+      ts.orb_pct, ts.drb_pct, ts.trb_pct, ts.ast_pct, ts.tov_pct, ts.usg_pct, ts.ts_pct
     FROM team_stats ts
     LEFT JOIN teams t ON ts.team_id = t.team_id
     WHERE ts.team_id = $1 AND ts.season = $2
@@ -55,6 +56,13 @@ async function getTeamStats(teamId, season, db) {
       stl_avg: team.stl_avg,
       blk_avg: team.blk_avg,
       pts_avg: team.pts_avg,
+      orb_pct: team.orb_pct,
+      drb_pct: team.drb_pct,
+      trb_pct: team.trb_pct,
+      ast_pct: team.ast_pct,
+      tov_pct: team.tov_pct,
+      usg_pct: team.usg_pct,
+      ts_pct: team.ts_pct,
     },
   };
 }

--- a/frontend/src/components/RankingsGrid.jsx
+++ b/frontend/src/components/RankingsGrid.jsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 import { useRankings } from '../hooks/useApi';
-import { formatStatValue } from '../utils/statFormatter';
+import { formatStatValue, formatPercentageStat } from '../utils/statFormatter';
 
 const TEAM_ID_TO_ABBR = {
   1610612737: 'ATL', 1610612738: 'BOS', 1610612739: 'CLE', 1610612740: 'NOP',
@@ -35,7 +35,7 @@ export function RankingsGrid({ category, season = '2025' }) {
     );
   }
 
-  if (!data || !data.data || data.data.length === 0) {
+  if (!data || !data.rankings || data.rankings.length === 0) {
     return (
       <div className="alert alert-info">
         <svg xmlns="http://www.w3.org/2000/svg" className="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24">
@@ -63,7 +63,7 @@ export function RankingsGrid({ category, season = '2025' }) {
           </tr>
         </thead>
         <tbody>
-          {data.data.map((item) => (
+          {data.rankings.map((item) => (
             <tr key={`${item.team_id}-${item.stat_category}`}>
               <td>
                 <span className={`badge badge-lg ${getRankColor(item.rank)}`}>
@@ -96,7 +96,10 @@ export function RankingsGrid({ category, season = '2025' }) {
                 </Link>
               </td>
               <td className="text-right text-lg font-bold">
-                {formatStatValue(item.value, data.label)}
+                {["TS%", "ORB%", "DRB%", "TRB%", "AST%", "USG%"].includes(data.category)
+                  ? formatPercentageStat(item.value, data.label)
+                  : formatStatValue(item.value, data.label)
+                }
               </td>
             </tr>
           ))}

--- a/frontend/src/components/Top5Showcase.jsx
+++ b/frontend/src/components/Top5Showcase.jsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 import { useAllTeams } from '../hooks/useApi';
-import { formatStatValue } from '../utils/statFormatter';
+import { formatStatValue, formatPercentageStat } from '../utils/statFormatter';
 
 // Team ID to abbreviation mapping for routing
 const TEAM_ID_TO_ABBR = {
@@ -16,12 +16,12 @@ const TEAM_ID_TO_ABBR = {
 
 export function Top5Showcase({ rankings, category, shouldAnimate = true }) {
   const { data: allTeams } = useAllTeams();
-  if (!rankings || !rankings.data || rankings.data.length === 0) {
+  if (!rankings || !rankings.rankings || rankings.rankings.length === 0) {
     return null;
   }
 
   // Get top 5 teams
-  const top5 = rankings.data.slice(0, 5);
+  const top5 = rankings.rankings.slice(0, 5);
 
   // Calculate contrast ratio for white text on a given hex color
   const getContrastRatio = (hexColor) => {
@@ -112,7 +112,10 @@ export function Top5Showcase({ rankings, category, shouldAnimate = true }) {
                   
                   {/* Stat value */}
                   <div className="text-lg font-bold whitespace-nowrap">
-                    {formatStatValue(team.value, rankings.label)}
+                    {["TS%", "ORB%", "DRB%", "TRB%", "AST%", "USG%"].includes(rankings.category)
+                      ? formatPercentageStat(team.value, rankings.label)
+                      : formatStatValue(team.value, rankings.label)
+                    }
                   </div>
                 </div>
               </div>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -95,22 +95,6 @@ export function Dashboard() {
                 />
               </div>
             </div>
-
-            {/* Quick Stats Cards */}
-            <div className="mt-6">
-              <h2 className="text-2xl font-bold mb-4">Popular Stats</h2>
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                {categories?.slice(0, 4).map((stat) => (
-                  <button
-                    key={stat.code}
-                    onClick={() => setSelectedCategory(stat.code)}
-                    className={`btn btn-outline ${selectedCategory === stat.code ? 'btn-active' : ''}`}
-                  >
-                    {stat.code}
-                  </button>
-                ))}
-              </div>
-            </div>
           </>
         )}
 

--- a/frontend/src/pages/RankingsPage.jsx
+++ b/frontend/src/pages/RankingsPage.jsx
@@ -80,22 +80,6 @@ export function RankingsPage() {
           />
         </div>
       </div>
-
-      {/* Quick Stats Cards */}
-      <div className="mt-6">
-        <h2 className="text-2xl font-bold mb-4">Popular Stats</h2>
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          {categories?.slice(0, 4).map((stat) => (
-            <button
-              key={stat.code}
-              onClick={() => setSelectedCategory(stat.code)}
-              className={`btn btn-outline ${selectedCategory === stat.code ? 'btn-active' : ''}`}
-            >
-              {stat.code}
-            </button>
-          ))}
-        </div>
-      </div>
     </>
   );
 }

--- a/frontend/src/pages/TeamPage.jsx
+++ b/frontend/src/pages/TeamPage.jsx
@@ -79,23 +79,28 @@ export function TeamPage() {
       'APG': stats.ast_avg,
       'SPG': stats.stl_avg,
       'BPG': stats.blk_avg,
-      'FG%': stats.fg_pct ? stats.fg_pct * 100 : null,
-      '3P%': stats.three_p_pct ? stats.three_p_pct * 100 : null,
-      'FT%': stats.ft_pct ? stats.ft_pct * 100 : null,
-      'TS%': stats.ts_pct ? stats.ts_pct * 100 : null,
-      'ORB%': stats.orb_pct ? stats.orb_pct * 100 : null,
-      'DRB%': stats.drb_pct ? stats.drb_pct * 100 : null,
-      'TRB%': stats.trb_pct ? stats.trb_pct * 100 : null,
-      'AST%': stats.ast_pct ? stats.ast_pct * 100 : null,
-      'USG%': stats.usg_pct ? stats.usg_pct * 100 : null,
-      'TOV%': stats.tov_pct ? stats.tov_pct * 100 : null,
+      'FG%': stats.fg_pct,
+      '3P%': stats.three_p_pct,
+      'FT%': stats.ft_pct,
+      'TS%': stats.ts_pct,
+      'ORB%': stats.orb_pct,
+      'DRB%': stats.drb_pct,
+      'TRB%': stats.trb_pct,
+      'AST%': stats.ast_pct,
+      'USG%': stats.usg_pct,
+      'TOV%': stats.tov_pct,
     };
     
     const value = statMap[category];
     if (value === null || value === undefined) return '-';
     
-    // Get the category label to determine if it's a percentage
+    // Get the category label to determine formatting
     const categoryLabel = categories?.find(c => c.code === category)?.label || category;
+    
+    // Use formatPercentageStat for advanced percentages, formatStatValue for others
+    if (["TS%", "ORB%", "DRB%", "TRB%", "AST%", "USG%"].includes(category)) {
+      return formatPercentageStat(value, categoryLabel);
+    }
     return formatStatValue(value, categoryLabel);
   };
 
@@ -181,10 +186,13 @@ export function TeamPage() {
                         )}
                       </td>
                       <td className="text-right font-semibold">
-                        {ranking ? 
-                          formatStatValue(ranking.value, category.label)
-                          : getFormattedStatValue(category.code)
-                        }
+                        {ranking ? (
+                          ["TS%", "ORB%", "DRB%", "TRB%", "AST%", "USG%"].includes(category.code)
+                            ? formatPercentageStat(ranking.value, category.label)
+                            : formatStatValue(ranking.value, category.label)
+                        ) : (
+                          getFormattedStatValue(category.code)
+                        )}
                       </td>
                     </tr>
                   );


### PR DESCRIPTION
Closes #26

## Changes
- **Incremental fetch**: Removed `clear_season_data()` from fetch script so it skips already-collected games instead of wiping derived data on every run
- **USG% field fix**: Changed `usagePercentage` (always returned 1.0) to `estimatedUsagePercentage` for actual values
- **Advanced stat precision**: Increased decimal precision from 1 to 4 for advanced percentage stats (ORB%, DRB%, TRB%, AST%, USG%, TS%)
- **Rankings API**: Renamed response key from `data` to `rankings` for clarity
- **Team detail endpoint**: Added advanced stats (orb_pct, drb_pct, trb_pct, ast_pct, tov_pct, usg_pct, ts_pct) to team stats query
- **Percentage formatting**: Added `formatPercentageStat` for proper display of advanced percentage stats
- **UI cleanup**: Removed redundant "Popular Stats" quick buttons from Dashboard and Rankings pages