### PR TITLE
fix: stabilize audit table column widths on row expand #21

### DIFF
--- a/frontend/src/components/AuditTab.jsx
+++ b/frontend/src/components/AuditTab.jsx
@@ -255,7 +255,7 @@ export function AuditTab({ season }) {
           <h3 className="card-title text-lg">Game Collection Details</h3>
           
           <div className="overflow-x-auto">
-            <table className="table table-compact w-full">
+            <table className="table table-compact table-fixed w-full">
               <thead>
                 <tr>
                   <th>Game ID</th>

--- a/frontend/src/components/GameStatsRow.jsx
+++ b/frontend/src/components/GameStatsRow.jsx
@@ -15,7 +15,7 @@ const GameStatsRow = ({ homeStats, awayStats, isLoading, error, onRetry }) => {
   if (isLoading) {
     return (
       <tr className="bg-base-200">
-        <td colSpan="10" className="text-center py-8">
+        <td colSpan="5" className="text-center py-8">
           <span className="loading loading-spinner loading-lg"></span>
         </td>
       </tr>
@@ -25,7 +25,7 @@ const GameStatsRow = ({ homeStats, awayStats, isLoading, error, onRetry }) => {
   if (error) {
     return (
       <tr className="bg-base-200">
-        <td colSpan="10">
+        <td colSpan="5">
           <div className="p-6 text-center">
             <p className="text-error mb-4">{error}</p>
             <button
@@ -67,8 +67,8 @@ const GameStatsRow = ({ homeStats, awayStats, isLoading, error, onRetry }) => {
 
   return (
     <tr className="bg-base-200">
-      <td colSpan="10" className="p-0 flex justify-center w-full">
-        <div className="p-6 space-y-1 w-full max-w-full overflow-x-hidden">
+      <td colSpan="5" className="p-0">
+        <div className="p-6 space-y-1 max-w-lg mx-auto">
           {/* Team Names with Logos */}
           <div className="grid grid-cols-[1fr_auto_1fr] gap-4 py-2 border-b border-base-300 px-4">
             <div className="text-right font-semibold flex items-center justify-end gap-2">


### PR DESCRIPTION
Closes #21

## Changes
- Fix `colSpan` mismatch (10 → 5) in GameStatsRow expanded states
- Remove `display: flex` from expanded `<td>` that was breaking table layout
- Constrain expanded game stats content width with `max-w-lg mx-auto`
- Add `table-fixed` to lock column widths from header definitions