### PR TITLE
Add rate limiting middleware to protect API endpoints - Issue #49

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -25,6 +25,7 @@
     "cors": "^2.8.6",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.3.1",
     "helmet": "^8.1.0",
     "ioredis": "^5.10.0",
     "node-cron": "^4.2.1",

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -17,6 +17,7 @@ const db = require("./db/postgresClient");
 const cache = require("./cache/redisClient");
 const { runMigrations } = require("../migrations/001_init_schema");
 const apiRoutes = require("./routes/api");
+const { apiLimiter } = require("./middleware/rateLimiter");
 
 const app = express();
 const PORT = process.env.PORT || 5000;
@@ -52,8 +53,9 @@ app.get("/health", (req, res) => {
   });
 });
 
-// API Routes
-app.use("/api", apiRoutes);
+// API Routes with rate limiting
+// Apply general rate limiter to all API endpoints
+app.use("/api", apiLimiter, apiRoutes);
 
 /**
  * Error handler for URL decoding errors

--- a/backend/src/middleware/rateLimiter.js
+++ b/backend/src/middleware/rateLimiter.js
@@ -1,0 +1,50 @@
+const rateLimit = require("express-rate-limit");
+
+/**
+ * Standard rate limiter for general API endpoints
+ * 30 requests per 15 minutes per IP address
+ */
+const apiLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 30, // limit each IP to 30 requests per windowMs
+  message:
+    "Too many requests from this IP address, please try again after 15 minutes",
+  standardHeaders: true, // Return rate limit info in the RateLimit-* headers
+  legacyHeaders: false, // Disable the X-RateLimit-* headers
+  skip: (req) => {
+    // Skip rate limiting for health check endpoint
+    return req.path === "/health";
+  },
+});
+
+/**
+ * Strict rate limiter for rankings endpoints
+ * 15 requests per 15 minutes per IP address (more expensive database queries)
+ */
+const rankingsLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 15, // limit each IP to 15 requests per windowMs
+  message:
+    "Too many ranking requests from this IP, please try again after 15 minutes",
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+/**
+ * Very strict rate limiter for team stats endpoints
+ * 20 requests per 15 minutes per IP address
+ */
+const teamStatsLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 20, // limit each IP to 20 requests per windowMs
+  message:
+    "Too many team stats requests from this IP, please try again after 15 minutes",
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+module.exports = {
+  apiLimiter,
+  rankingsLimiter,
+  teamStatsLimiter,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      express-rate-limit:
+        specifier: ^8.3.1
+        version: 8.3.1(express@5.2.1)
       helmet:
         specifier: ^8.1.0
         version: 8.1.0
@@ -1742,6 +1745,12 @@ packages:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  express-rate-limit@8.3.1:
+    resolution: {integrity: sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
@@ -2012,6 +2021,10 @@ packages:
   ioredis@5.10.0:
     resolution: {integrity: sha512-HVBe9OFuqs+Z6n64q09PQvP1/R4Bm+30PAyyD4wIEqssh3v9L21QjCVk4kRLucMBcDokJTcLjsGeVRlq/nH6DA==}
     engines: {node: '>=12.22.0'}
+
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -5323,6 +5336,11 @@ snapshots:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
 
+  express-rate-limit@8.3.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
@@ -5625,6 +5643,8 @@ snapshots:
       standard-as-callback: 2.1.0
     transitivePeerDependencies:
       - supports-color
+
+  ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
 


### PR DESCRIPTION
- Installed express-rate-limit package
- Created rateLimiter.js middleware with three rate limit configurations:
  - apiLimiter: 30 requests per 15 minutes (general API endpoints)
  - rankingsLimiter: 15 requests per 15 minutes (expensive database queries)
  - teamStatsLimiter: 20 requests per 15 minutes (team stats endpoints)
- Applied rate limiting to all /api routes to protect against DoS attacks
- Health check endpoint excluded from rate limiting
- Uses standard RateLimit-* headers for client feedback

Protection against:
- Abuse from malicious actors
- Unintended DoS attacks from client bugs
- Bot scraping of API data

Closes #49