### PR TITLE
Add npm audit to CI workflows to block vulnerable dependencies - Issu…

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -25,5 +25,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Audit dependencies for vulnerabilities
+        run: pnpm audit --audit-level=moderate
+
       - name: Run backend tests
         run: pnpm --filter backend test

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -25,5 +25,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Audit dependencies for vulnerabilities
+        run: pnpm audit --audit-level=moderate
+
       - name: Run frontend tests
         run: pnpm --filter frontend test


### PR DESCRIPTION
…e #58

- Added pnpm audit --audit-level=moderate to backend CI pipeline
- Added pnpm audit --audit-level=moderate to frontend CI pipeline
- Audit runs after dependencies installed, before tests
- Will fail CI if moderate, high, or critical vulnerabilities detected
- Prevents vulnerable code from merging to production

Closes #58