### PR TITLE
Add API contract tests with Zod response schemas - Issue #47

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -40,6 +40,7 @@
     "jest": "^29.7.0",
     "nodemon": "^3.1.14",
     "prettier": "^3.8.1",
-    "supertest": "^6.3.3"
+    "supertest": "^6.3.3",
+    "zod": "^4.3.6"
   }
 }

--- a/backend/src/__tests__/routes.contract.test.js
+++ b/backend/src/__tests__/routes.contract.test.js
@@ -1,0 +1,317 @@
+const request = require("supertest");
+
+// Mock db and cache BEFORE importing app so route modules get the mocked versions
+jest.mock("../db/postgresClient", () => ({
+  query: jest.fn(),
+  pool: { end: jest.fn() },
+}));
+
+jest.mock("../cache/redisClient", () => ({
+  get: jest.fn(),
+  set: jest.fn(),
+  del: jest.fn(),
+  redis: { quit: jest.fn() },
+}));
+
+// Bypass rate limiting in tests
+jest.mock("../middleware/rateLimiter", () => ({
+  apiLimiter: (req, res, next) => next(),
+  rankingsLimiter: (req, res, next) => next(),
+  teamStatsLimiter: (req, res, next) => next(),
+}));
+
+const app = require("../app");
+const db = require("../db/postgresClient");
+const cache = require("../cache/redisClient");
+
+const {
+  HealthResponseSchema,
+  CategoriesResponseSchema,
+  RankingsResponseSchema,
+  TeamsResponseSchema,
+  TeamByAbbrResponseSchema,
+  TeamStatsResponseSchema,
+  TeamRankingsResponseSchema,
+  AuditGamesResponseSchema,
+  AuditGameStatsResponseSchema,
+} = require("../schemas/responseSchemas");
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  cache.get.mockResolvedValue(null);
+  cache.set.mockResolvedValue("OK");
+});
+
+// Helper to run a Zod parse and surface detailed errors on failure
+function assertSchema(schema, body) {
+  const result = schema.safeParse(body);
+  if (!result.success) {
+    // Jest will print this in the failure output for easy debugging
+    throw new Error(`Schema validation failed:\n${JSON.stringify(result.error.format(), null, 2)}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GET /health
+// ---------------------------------------------------------------------------
+describe("GET /health — contract", () => {
+  it("response matches HealthResponseSchema", async () => {
+    const res = await request(app).get("/health");
+    assertSchema(HealthResponseSchema, res.body);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/categories
+// ---------------------------------------------------------------------------
+describe("GET /api/categories — contract", () => {
+  it("response matches CategoriesResponseSchema", async () => {
+    const res = await request(app).get("/api/categories");
+    assertSchema(CategoriesResponseSchema, res.body);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/rankings
+// ---------------------------------------------------------------------------
+describe("GET /api/rankings — contract", () => {
+  it("response matches RankingsResponseSchema (cache miss)", async () => {
+    db.query.mockResolvedValue({
+      rows: [
+        {
+          team_id: 1610612751,
+          team_name: "Brooklyn Nets",
+          stat_category: "PPG",
+          rank: 1,
+          value: 115.4,
+          logo_url: null,
+          games_count: 82,
+        },
+      ],
+      rowCount: 1,
+    });
+
+    const res = await request(app).get("/api/rankings?category=PPG");
+    assertSchema(RankingsResponseSchema, res.body);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/teams
+// ---------------------------------------------------------------------------
+describe("GET /api/teams — contract", () => {
+  it("response matches TeamsResponseSchema", async () => {
+    db.query.mockResolvedValue({
+      rows: [
+        {
+          id: 1,
+          team_id: 1610612751,
+          team_name: "Brooklyn Nets",
+          logo_url: null,
+          team_colors: null,
+        },
+      ],
+      rowCount: 1,
+    });
+
+    const res = await request(app).get("/api/teams");
+    assertSchema(TeamsResponseSchema, res.body);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/teams/abbr/:abbreviation
+// ---------------------------------------------------------------------------
+describe("GET /api/teams/abbr/:abbreviation — contract", () => {
+  it("response matches TeamByAbbrResponseSchema", async () => {
+    db.query.mockResolvedValue({
+      rows: [
+        {
+          id: 1,
+          team_id: 1610612738,
+          team_name: "Boston Celtics",
+          logo_url: null,
+          team_colors: null,
+        },
+      ],
+      rowCount: 1,
+    });
+
+    const res = await request(app).get("/api/teams/abbr/BOS");
+    assertSchema(TeamByAbbrResponseSchema, res.body);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/team/:teamId/stats
+// ---------------------------------------------------------------------------
+describe("GET /api/team/:teamId/stats — contract", () => {
+  it("response matches TeamStatsResponseSchema", async () => {
+    db.query.mockResolvedValue({
+      rows: [
+        {
+          team_id: 1610612751,
+          team_name: "Brooklyn Nets",
+          season: 2024,
+          games_played: 82,
+          fg: 1568,
+          fga: 3350,
+          fg_pct: 0.468,
+          three_p: 600,
+          three_pa: 1600,
+          three_p_pct: 0.375,
+          ft: 400,
+          fta: 500,
+          ft_pct: 0.8,
+          oreb: 400,
+          dreb: 1000,
+          reb: 1400,
+          ast: 2337,
+          tov: 900,
+          stl: 500,
+          blk: 300,
+          pf: 1200,
+          pts: 9462,
+          fg_avg: 19.1,
+          fga_avg: 40.9,
+          three_p_avg: 7.3,
+          reb_avg: 17.1,
+          ast_avg: 28.5,
+          tov_avg: 11.0,
+          stl_avg: 6.1,
+          blk_avg: 3.7,
+          pts_avg: 115.4,
+          orb_pct: null,
+          drb_pct: null,
+          trb_pct: null,
+          ast_pct: null,
+          tov_pct: null,
+          usg_pct: null,
+          ts_pct: null,
+        },
+      ],
+      rowCount: 1,
+    });
+
+    const res = await request(app).get("/api/team/1610612751/stats");
+    assertSchema(TeamStatsResponseSchema, res.body);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/team/:teamId/rankings
+// ---------------------------------------------------------------------------
+describe("GET /api/team/:teamId/rankings — contract", () => {
+  it("response matches TeamRankingsResponseSchema", async () => {
+    db.query.mockResolvedValue({
+      rows: [
+        {
+          team_id: 1610612751,
+          team_name: "Brooklyn Nets",
+          stat_category: "PPG",
+          rank: 4,
+          value: 115.4,
+        },
+      ],
+      rowCount: 1,
+    });
+
+    const res = await request(app).get("/api/team/1610612751/rankings");
+    assertSchema(TeamRankingsResponseSchema, res.body);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/audit/games
+// ---------------------------------------------------------------------------
+describe("GET /api/audit/games — contract", () => {
+  it("response matches AuditGamesResponseSchema", async () => {
+    db.query
+      .mockResolvedValueOnce({
+        rows: [
+          { season: "2025", total_games: 100, collected_games: 80, collection_percentage: "80.00" },
+        ],
+        rowCount: 1,
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            game_id: "g1",
+            game_date: "2024-01-01",
+            home_team_id: 1610612738,
+            home_team_abbreviation: "BOS",
+            home_team_logo: null,
+            away_team_id: 1610612747,
+            away_team_abbreviation: "LAL",
+            away_team_logo: null,
+            collected: true,
+            created_at: "2024-01-01T00:00:00.000Z",
+            updated_at: "2024-01-01T00:00:00.000Z",
+          },
+        ],
+        rowCount: 1,
+      });
+
+    const res = await request(app).get("/api/audit/games");
+    assertSchema(AuditGamesResponseSchema, res.body);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/audit/game/:gameId/stats
+// ---------------------------------------------------------------------------
+describe("GET /api/audit/game/:gameId/stats — contract", () => {
+  it("response matches AuditGameStatsResponseSchema (percentages are numbers)", async () => {
+    db.query.mockResolvedValue({
+      rows: [
+        {
+          game_id: "g1",
+          game_date: "2024-01-01",
+          team_id: 1610612738,
+          abbreviation: "BOS",
+          logo_url: null,
+          pts: 110,
+          reb: 45,
+          ast: 25,
+          stl: 8,
+          blk: 5,
+          // node-postgres returns NUMERIC as strings — service normalizes to number
+          fg_pct: "46.00",
+          ft_pct: "78.00",
+          three_p_pct: "37.00",
+          fg: 40,
+          fga: 87,
+          ft: 18,
+          fta: 23,
+          three_p: 12,
+          three_pa: 32,
+        },
+        {
+          game_id: "g1",
+          game_date: "2024-01-01",
+          team_id: 1610612747,
+          abbreviation: "LAL",
+          logo_url: null,
+          pts: 105,
+          reb: 42,
+          ast: 22,
+          stl: 6,
+          blk: 4,
+          fg_pct: "44.00",
+          ft_pct: "75.00",
+          three_p_pct: "35.00",
+          fg: 38,
+          fga: 86,
+          ft: 15,
+          fta: 20,
+          three_p: 10,
+          three_pa: 28,
+        },
+      ],
+      rowCount: 2,
+    });
+
+    const res = await request(app).get("/api/audit/game/g1/stats");
+    assertSchema(AuditGameStatsResponseSchema, res.body);
+  });
+});

--- a/backend/src/schemas/responseSchemas.js
+++ b/backend/src/schemas/responseSchemas.js
@@ -1,0 +1,185 @@
+const { z } = require("zod");
+
+// ---------------------------------------------------------------------------
+// Shared sub-schemas
+// ---------------------------------------------------------------------------
+
+const TeamRowSchema = z.object({
+  id: z.number().int(),
+  team_id: z.number().int(),
+  team_name: z.string(),
+  logo_url: z.string().nullable(),
+  team_colors: z.unknown().nullable(),
+});
+
+const RankingItemSchema = z.object({
+  team_id: z.number().int(),
+  team_name: z.string(),
+  stat_category: z.string(),
+  rank: z.number().int(),
+  value: z.number(),
+  logo_url: z.string().nullable(),
+  games_count: z.number().int(),
+});
+
+const TeamGameStatsSchema = z.object({
+  game_id: z.string(),
+  game_date: z.string(),
+  team_id: z.number().int(),
+  abbreviation: z.string(),
+  logo_url: z.string().nullable(),
+  pts: z.number(),
+  reb: z.number(),
+  ast: z.number(),
+  stl: z.number(),
+  blk: z.number(),
+  fg_pct: z.number(),
+  ft_pct: z.number(),
+  three_p_pct: z.number(),
+  fg: z.number(),
+  fga: z.number(),
+  ft: z.number(),
+  fta: z.number(),
+  three_p: z.number(),
+  three_pa: z.number(),
+});
+
+const TeamStatsObjectSchema = z.object({
+  fg: z.number(),
+  fga: z.number(),
+  fg_pct: z.number(),
+  three_p: z.number(),
+  three_pa: z.number(),
+  three_p_pct: z.number(),
+  ft: z.number(),
+  fta: z.number(),
+  ft_pct: z.number(),
+  oreb: z.number(),
+  dreb: z.number(),
+  reb: z.number(),
+  ast: z.number(),
+  tov: z.number(),
+  stl: z.number(),
+  blk: z.number(),
+  pf: z.number(),
+  pts: z.number(),
+  fg_avg: z.number(),
+  fga_avg: z.number(),
+  three_p_avg: z.number(),
+  reb_avg: z.number(),
+  ast_avg: z.number(),
+  tov_avg: z.number(),
+  stl_avg: z.number(),
+  blk_avg: z.number(),
+  pts_avg: z.number(),
+  orb_pct: z.number().nullable(),
+  drb_pct: z.number().nullable(),
+  trb_pct: z.number().nullable(),
+  ast_pct: z.number().nullable(),
+  tov_pct: z.number().nullable(),
+  usg_pct: z.number().nullable(),
+  ts_pct: z.number().nullable(),
+});
+
+// ---------------------------------------------------------------------------
+// Endpoint response schemas
+// ---------------------------------------------------------------------------
+
+const HealthResponseSchema = z.object({
+  status: z.literal("healthy"),
+  timestamp: z.string().datetime(),
+  api: z.literal("ok"),
+});
+
+const CategoriesResponseSchema = z.object({
+  success: z.literal(true),
+  categories: z.array(
+    z.object({
+      code: z.string(),
+      label: z.string(),
+    })
+  ),
+});
+
+const RankingsResponseSchema = z.object({
+  success: z.literal(true),
+  rankings: z.array(RankingItemSchema),
+  category: z.string(),
+  label: z.string(),
+  cached: z.boolean(),
+  fetched_at: z.string().datetime().optional(),
+  cached_at: z.string().datetime().optional(),
+});
+
+const TeamsResponseSchema = z.object({
+  success: z.literal(true),
+  data: z.array(TeamRowSchema),
+});
+
+const TeamByAbbrResponseSchema = z.object({
+  success: z.literal(true),
+  data: TeamRowSchema,
+});
+
+const TeamStatsResponseSchema = z.object({
+  success: z.literal(true),
+  data: z.object({
+    team_id: z.number().int(),
+    team_name: z.string(),
+    season: z.union([z.number().int(), z.string()]),
+    games_played: z.number().int(),
+    stats: TeamStatsObjectSchema,
+  }),
+});
+
+const TeamRankingsResponseSchema = z.object({
+  success: z.literal(true),
+  data: z.object({
+    team_name: z.string(),
+    rankings: z.array(
+      z.object({
+        stat_category: z.string(),
+        rank: z.number().int(),
+        value: z.number(),
+      })
+    ),
+  }),
+});
+
+const AuditGamesResponseSchema = z.object({
+  success: z.literal(true),
+  stats: z.object({
+    season: z.union([z.number(), z.string()]),
+    total_games: z.union([z.number(), z.string()]),
+    collected_games: z.union([z.number(), z.string()]),
+    collection_percentage: z.union([z.number(), z.string()]),
+  }),
+  games: z.array(z.record(z.string(), z.unknown())),
+  pagination: z.object({
+    limit: z.number().int(),
+    offset: z.number().int(),
+    total: z.number().int(),
+  }),
+});
+
+const AuditGameStatsResponseSchema = z.object({
+  success: z.literal(true),
+  data: z.object({
+    game_id: z.string(),
+    game_date: z.string(),
+    home: TeamGameStatsSchema,
+    away: TeamGameStatsSchema.nullable(),
+  }),
+});
+
+module.exports = {
+  HealthResponseSchema,
+  CategoriesResponseSchema,
+  RankingsResponseSchema,
+  TeamsResponseSchema,
+  TeamByAbbrResponseSchema,
+  TeamStatsResponseSchema,
+  TeamRankingsResponseSchema,
+  AuditGamesResponseSchema,
+  AuditGameStatsResponseSchema,
+};

--- a/backend/src/services/auditService.js
+++ b/backend/src/services/auditService.js
@@ -133,12 +133,20 @@ async function getGameStats(gameId, db) {
     throw new Error(`No stats found for game ${gameId}`);
   }
 
+  // node-postgres returns NUMERIC columns as strings; normalize to numbers
+  const normalizeRow = (row) => ({
+    ...row,
+    fg_pct: parseFloat(row.fg_pct),
+    ft_pct: parseFloat(row.ft_pct),
+    three_p_pct: parseFloat(row.three_p_pct),
+  });
+
   // Organize by home (lower team_id) and away (higher team_id)
   const stats = {
     game_id: rows[0].game_id,
     game_date: rows[0].game_date,
-    home: rows[0],
-    away: rows[1] || null,
+    home: normalizeRow(rows[0]),
+    away: rows[1] ? normalizeRow(rows[1]) : null,
   };
 
   return stats;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       supertest:
         specifier: ^6.3.3
         version: 6.3.4
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
 
   frontend:
     dependencies:
@@ -3739,6 +3742,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
 
@@ -7820,3 +7826,5 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  zod@4.3.6: {}


### PR DESCRIPTION
## Description
Adds Zod-based response schema validation for all 9 API endpoints. Schemas are defined in a reusable module that can be imported for runtime validation in the future. Also fixes a type inconsistency where game stats percentages (fg_pct, ft_pct, three_p_pct) were returned as strings by PostgreSQL NUMERIC columns but all other percentage fields are floats.

## Changes
- Fixed `auditService.js` -- added `normalizeRow()` that applies `parseFloat()` to game stats percentage fields so they are consistent floats across all endpoints
- Created `backend/src/schemas/responseSchemas.js` -- Zod schemas for all 9 endpoint responses: HealthResponseSchema, CategoriesResponseSchema, RankingsResponseSchema, TeamsResponseSchema, TeamByAbbrResponseSchema, TeamStatsResponseSchema, TeamRankingsResponseSchema, AuditGamesResponseSchema, AuditGameStatsResponseSchema
- Created `backend/src/__tests__/routes.contract.test.js` -- 9 contract tests, one per endpoint, each validating the full response shape against the Zod schema
- Added zod devDependency to backend/package.json

## Test Results
All 110 tests pass (9 new contract tests + 101 existing tests)

Closes #47
