### PR TITLE
Add K6 load tests for 1000+ daily users baseline - Issue #62

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -1,0 +1,61 @@
+name: Load Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Base URL of the backend server to test against"
+        required: true
+        default: "http://localhost:5001"
+      test_suite:
+        description: "Which test suite to run"
+        required: true
+        default: "smoke_and_load"
+        type: choice
+        options:
+          - smoke_only
+          - smoke_and_load
+          - all
+
+jobs:
+  k6-load-test:
+    name: K6 Load Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run smoke test
+        uses: grafana/k6-action@v0.3.1
+        env:
+          BASE_URL: ${{ github.event.inputs.base_url }}
+        with:
+          filename: load-tests/smoke.js
+
+      - name: Run load test (baseline — 20 VUs)
+        if: >
+          github.event.inputs.test_suite == 'smoke_and_load' ||
+          github.event.inputs.test_suite == 'all'
+        uses: grafana/k6-action@v0.3.1
+        env:
+          BASE_URL: ${{ github.event.inputs.base_url }}
+        with:
+          filename: load-tests/load.js
+          flags: "--out json=k6-summary.json"
+
+      - name: Run stress test (50 VUs — degradation threshold)
+        if: github.event.inputs.test_suite == 'all'
+        uses: grafana/k6-action@v0.3.1
+        env:
+          BASE_URL: ${{ github.event.inputs.base_url }}
+        with:
+          filename: load-tests/stress.js
+          flags: "--out json=k6-stress-summary.json"
+
+      - name: Upload k6 results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: k6-summary
+          path: "*.json"
+          if-no-files-found: ignore

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: backend frontend services stop pipeline
+.PHONY: backend frontend services stop pipeline k6-smoke k6-load k6-stress
 
 # ── Infrastructure ───────────────────────────────────────────────────────────
 services:
@@ -42,6 +42,21 @@ pipeline:
 	python scripts/derive_rankings.py && \
 	redis-cli FLUSHDB
 	@echo "✅ Full pipeline complete — rankings updated"
+
+# ── Load Testing (k6) ────────────────────────────────────────────────────────
+# Requires: k6 installed (brew install k6) and a running backend server.
+# Override the target URL with: BASE_URL=https://your-server.com make k6-load
+
+BASE_URL ?= http://localhost:5001
+
+k6-smoke:
+	BASE_URL=$(BASE_URL) k6 run load-tests/smoke.js
+
+k6-load:
+	BASE_URL=$(BASE_URL) k6 run load-tests/load.js
+
+k6-stress:
+	BASE_URL=$(BASE_URL) k6 run load-tests/stress.js
 
 # ── Teardown ──────────────────────────────────────────────────────────────────
 stop:

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -1,0 +1,93 @@
+# Load Tests — K6 Baseline (Issue #62)
+
+Performance baseline for the NBA Stats Rankings API, targeting 1000+ daily users.
+
+## Prerequisites
+
+### Local Installation
+
+Install k6 via Homebrew (macOS):
+
+```bash
+brew install k6
+```
+
+Or via the official installer — see [k6 installation docs](https://grafana.com/docs/k6/latest/set-up/install-k6/).
+
+### Running Tests
+
+All tests accept a `BASE_URL` environment variable (defaults to `http://localhost:5001`).
+The backend server **must be running** with a live PostgreSQL + Redis connection.
+
+```bash
+# Quick sanity check (1 VU × 30s)
+make k6-smoke
+
+# Baseline load test (ramp to 20 VUs, ~5 min)
+make k6-load
+
+# Stress test (ramp to 50 VUs, find degradation point)
+make k6-stress
+
+# Against a deployed URL
+BASE_URL=https://your-server.com make k6-load
+```
+
+## Test Files
+
+| File        | Purpose                                  | VUs    | Duration |
+| ----------- | ---------------------------------------- | ------ | -------- |
+| `smoke.js`  | Sanity — all endpoints respond correctly | 1      | 30s      |
+| `load.js`   | Baseline — 1000 daily users model        | 0→20→0 | ~5 min   |
+| `stress.js` | Degradation — find the breaking point    | 0→50→0 | ~5 min   |
+
+### Scenarios (imported by all runners)
+
+| File                     | Endpoints Covered                                                                            |
+| ------------------------ | -------------------------------------------------------------------------------------------- |
+| `scenarios/dashboard.js` | `GET /health`, `/api/categories`, `/api/rankings?category=PPG`, `/api/rankings?category=RPG` |
+| `scenarios/teams.js`     | `GET /api/teams`, `/api/teams/abbr/BOS`, `/api/team/:id/stats`, `/api/team/:id/rankings`     |
+| `scenarios/audit.js`     | `GET /api/audit/games` (all, collected filter, missing filter)                               |
+
+> **Note:** `GET /api/audit/game/:gameId/stats` is excluded — it requires a real `gameId` from the database, which is not known at script time.
+
+## Pass/Fail Thresholds
+
+### Smoke & Load tests (blocking)
+
+| Metric                  | Threshold   | Rationale             |
+| ----------------------- | ----------- | --------------------- |
+| `http_req_failed`       | `rate < 1%` | <1% error rate        |
+| `http_req_duration` p95 | `< 500ms`   | Snappy UI experience  |
+| `http_req_duration` p99 | `< 1000ms`  | Worst-case acceptable |
+
+### Stress test (observational)
+
+| Metric                  | Threshold   | Rationale                   |
+| ----------------------- | ----------- | --------------------------- |
+| `http_req_failed`       | `rate < 5%` | Alert on severe degradation |
+| `http_req_duration` p99 | `< 3000ms`  | Alert on extreme latency    |
+
+## CI Integration
+
+Load tests run via a **manual `workflow_dispatch`** only (they require a live server). See [`.github/workflows/load-test.yml`](../.github/workflows/load-test.yml).
+
+To trigger from GitHub Actions UI:
+
+1. Go to **Actions → Load Tests**
+2. Click **Run workflow**
+3. Enter the `base_url` of a deployed environment
+4. Download the `k6-summary` artifact after the run completes
+
+## Load Model
+
+```
+1000 users/day × ~11 requests/session ÷ 8 peak hours ≈ 0.38 RPS average
+Baseline VU target: 20 concurrent users (conservative burst headroom)
+```
+
+Custom metrics are exported per flow for granular per-endpoint analysis:
+
+- `dashboard_req_duration` / `dashboard_req_errors`
+- `teams_req_duration` / `teams_req_errors`
+- `audit_req_duration` / `audit_req_errors`

--- a/load-tests/load.js
+++ b/load-tests/load.js
@@ -1,0 +1,48 @@
+/**
+ * Load Test — 1000+ daily users baseline
+ *
+ * Load model:
+ *   1000 users/day × ~11 requests/session ÷ 8 peak hours ≈ 0.38 RPS average
+ *   Burst target: 20 concurrent VUs (conservative peak headroom)
+ *
+ * Stages:
+ *   0 → 20 VUs over 1 min  (ramp up)
+ *   20 VUs held for 3 min  (steady state)
+ *   20 → 0 VUs over 1 min  (ramp down)
+ *   Total: ~5 minutes
+ *
+ * Usage:
+ *   k6 run load-tests/load.js
+ *   BASE_URL=https://your-server.com k6 run load-tests/load.js
+ *   make k6-load
+ */
+
+import dashboardScenario from "./scenarios/dashboard.js";
+import teamsScenario from "./scenarios/teams.js";
+import auditScenario from "./scenarios/audit.js";
+
+export const options = {
+  stages: [
+    { duration: "1m", target: 20 }, // ramp up to 20 VUs
+    { duration: "3m", target: 20 }, // hold at 20 VUs (steady state)
+    { duration: "1m", target: 0 }, // ramp down
+  ],
+  thresholds: {
+    // Baseline pass/fail criteria for 1000+ daily users
+    http_req_failed: ["rate<0.01"], // <1% error rate
+    http_req_duration: ["p(95)<500", "p(99)<1000"], // p95 < 500ms, p99 < 1s
+    // Per-flow thresholds
+    dashboard_req_errors: ["rate<0.01"],
+    teams_req_errors: ["rate<0.01"],
+    audit_req_errors: ["rate<0.01"],
+    dashboard_req_duration: ["p(95)<500"],
+    teams_req_duration: ["p(95)<500"],
+    audit_req_duration: ["p(95)<500"],
+  },
+};
+
+export default function () {
+  dashboardScenario();
+  teamsScenario();
+  auditScenario();
+}

--- a/load-tests/scenarios/audit.js
+++ b/load-tests/scenarios/audit.js
@@ -1,0 +1,90 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Trend, Rate } from "k6/metrics";
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:5001";
+
+export const auditDuration = new Trend("audit_req_duration", true);
+export const auditErrors = new Rate("audit_req_errors");
+
+/**
+ * Audit flow:
+ *   GET /api/audit/games?season=2025&limit=50&offset=0
+ *   GET /api/audit/games?season=2025&status=collected&limit=50&offset=0
+ *   GET /api/audit/games?season=2025&status=missing&limit=50&offset=0
+ *
+ * NOTE: /api/audit/game/:gameId/stats is intentionally excluded — it requires
+ * a real gameId from the database which is not known at script time.
+ */
+export default function auditScenario() {
+  // 1. All games (default view)
+  const allRes = http.get(
+    `${BASE_URL}/api/audit/games?season=2025&limit=50&offset=0`,
+    { tags: { name: "audit_all" } }
+  );
+  const allOk = check(allRes, {
+    "audit all: status 200": (r) => r.status === 200,
+    "audit all: has games array": (r) => {
+      try {
+        const body = JSON.parse(r.body);
+        return Array.isArray(body.games);
+      } catch {
+        return false;
+      }
+    },
+    "audit all: has stats": (r) => {
+      try {
+        const body = JSON.parse(r.body);
+        return body.stats && body.stats.total_games !== undefined;
+      } catch {
+        return false;
+      }
+    },
+  });
+  auditDuration.add(allRes.timings.duration, { endpoint: "audit_all" });
+  auditErrors.add(!allOk);
+
+  sleep(0.5);
+
+  // 2. Collected games only (status filter)
+  const collectedRes = http.get(
+    `${BASE_URL}/api/audit/games?season=2025&status=collected&limit=50&offset=0`,
+    { tags: { name: "audit_collected" } }
+  );
+  const collectedOk = check(collectedRes, {
+    "audit collected: status 200": (r) => r.status === 200,
+    "audit collected: has games array": (r) => {
+      try {
+        const body = JSON.parse(r.body);
+        return Array.isArray(body.games);
+      } catch {
+        return false;
+      }
+    },
+  });
+  auditDuration.add(collectedRes.timings.duration, { endpoint: "audit_collected" });
+  auditErrors.add(!collectedOk);
+
+  sleep(0.5);
+
+  // 3. Missing games only (least common, but validates filter path)
+  const missingRes = http.get(
+    `${BASE_URL}/api/audit/games?season=2025&status=missing&limit=50&offset=0`,
+    { tags: { name: "audit_missing" } }
+  );
+  const missingOk = check(missingRes, {
+    "audit missing: status 200": (r) => r.status === 200,
+    "audit missing: has games array": (r) => {
+      try {
+        const body = JSON.parse(r.body);
+        return Array.isArray(body.games);
+      } catch {
+        return false;
+      }
+    },
+  });
+  auditDuration.add(missingRes.timings.duration, { endpoint: "audit_missing" });
+  auditErrors.add(!missingOk);
+
+  sleep(1);
+}

--- a/load-tests/scenarios/dashboard.js
+++ b/load-tests/scenarios/dashboard.js
@@ -1,0 +1,96 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Trend, Rate } from "k6/metrics";
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:5001";
+
+export const dashboardDuration = new Trend("dashboard_req_duration", true);
+export const dashboardErrors = new Rate("dashboard_req_errors");
+
+/**
+ * Dashboard / Rankings flow:
+ *   GET /health
+ *   GET /api/categories
+ *   GET /api/rankings?category=PPG&season=2025
+ *   GET /api/rankings?category=RPG&season=2025
+ */
+export default function dashboardScenario() {
+  // 1. Health check
+  const healthRes = http.get(`${BASE_URL}/health`, { tags: { name: "health" } });
+  const healthOk = check(healthRes, {
+    "health: status 200": (r) => r.status === 200,
+    "health: has status field": (r) => {
+      try {
+        return JSON.parse(r.body).status !== undefined;
+      } catch {
+        return false;
+      }
+    },
+  });
+  dashboardDuration.add(healthRes.timings.duration, { endpoint: "health" });
+  dashboardErrors.add(!healthOk);
+
+  sleep(0.5);
+
+  // 2. Fetch categories
+  const catRes = http.get(`${BASE_URL}/api/categories`, {
+    tags: { name: "categories" },
+  });
+  const catOk = check(catRes, {
+    "categories: status 200": (r) => r.status === 200,
+    "categories: returns array": (r) => {
+      try {
+        const body = JSON.parse(r.body);
+        return Array.isArray(body.categories) && body.categories.length > 0;
+      } catch {
+        return false;
+      }
+    },
+  });
+  dashboardDuration.add(catRes.timings.duration, { endpoint: "categories" });
+  dashboardErrors.add(!catOk);
+
+  sleep(0.5);
+
+  // 3. Rankings — PPG (most common default view)
+  const ppgRes = http.get(
+    `${BASE_URL}/api/rankings?category=PPG&season=2025`,
+    { tags: { name: "rankings_ppg" } }
+  );
+  const ppgOk = check(ppgRes, {
+    "rankings PPG: status 200": (r) => r.status === 200,
+    "rankings PPG: has rankings array": (r) => {
+      try {
+        const body = JSON.parse(r.body);
+        return Array.isArray(body.rankings);
+      } catch {
+        return false;
+      }
+    },
+  });
+  dashboardDuration.add(ppgRes.timings.duration, { endpoint: "rankings_ppg" });
+  dashboardErrors.add(!ppgOk);
+
+  sleep(0.5);
+
+  // 4. Rankings — RPG (second most common)
+  const rpgRes = http.get(
+    `${BASE_URL}/api/rankings?category=RPG&season=2025`,
+    { tags: { name: "rankings_rpg" } }
+  );
+  const rpgOk = check(rpgRes, {
+    "rankings RPG: status 200": (r) => r.status === 200,
+    "rankings RPG: has rankings array": (r) => {
+      try {
+        const body = JSON.parse(r.body);
+        return Array.isArray(body.rankings);
+      } catch {
+        return false;
+      }
+    },
+  });
+  dashboardDuration.add(rpgRes.timings.duration, { endpoint: "rankings_rpg" });
+  dashboardErrors.add(!rpgOk);
+
+  sleep(1);
+}

--- a/load-tests/scenarios/teams.js
+++ b/load-tests/scenarios/teams.js
@@ -1,0 +1,103 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Trend, Rate } from "k6/metrics";
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:5001";
+
+// Boston Celtics — guaranteed to exist in the dataset
+const TEAM_ID = "1610612738";
+const TEAM_ABBR = "BOS";
+
+export const teamsDuration = new Trend("teams_req_duration", true);
+export const teamsErrors = new Rate("teams_req_errors");
+
+/**
+ * Teams flow:
+ *   GET /api/teams
+ *   GET /api/teams/abbr/BOS
+ *   GET /api/team/1610612738/stats?season=2025
+ *   GET /api/team/1610612738/rankings?season=2025
+ */
+export default function teamsScenario() {
+  // 1. All teams list
+  const allTeamsRes = http.get(`${BASE_URL}/api/teams`, {
+    tags: { name: "teams_list" },
+  });
+  const allTeamsOk = check(allTeamsRes, {
+    "teams list: status 200": (r) => r.status === 200,
+    "teams list: returns array": (r) => {
+      try {
+        const body = JSON.parse(r.body);
+        return Array.isArray(body.data) && body.data.length > 0;
+      } catch {
+        return false;
+      }
+    },
+  });
+  teamsDuration.add(allTeamsRes.timings.duration, { endpoint: "teams_list" });
+  teamsErrors.add(!allTeamsOk);
+
+  sleep(0.5);
+
+  // 2. Team by abbreviation (simulates clicking a team card)
+  const abbrRes = http.get(`${BASE_URL}/api/teams/abbr/${TEAM_ABBR}`, {
+    tags: { name: "teams_abbr" },
+  });
+  const abbrOk = check(abbrRes, {
+    "team by abbr: status 200": (r) => r.status === 200,
+    "team by abbr: has team_id": (r) => {
+      try {
+        const body = JSON.parse(r.body);
+        return body.data && body.data.team_id !== undefined;
+      } catch {
+        return false;
+      }
+    },
+  });
+  teamsDuration.add(abbrRes.timings.duration, { endpoint: "teams_abbr" });
+  teamsErrors.add(!abbrOk);
+
+  sleep(0.5);
+
+  // 3. Team stats (parallel-ish in the UI, but sequential here for simplicity)
+  const statsRes = http.get(
+    `${BASE_URL}/api/team/${TEAM_ID}/stats?season=2025`,
+    { tags: { name: "team_stats" } }
+  );
+  const statsOk = check(statsRes, {
+    "team stats: status 200": (r) => r.status === 200,
+    "team stats: has data": (r) => {
+      try {
+        const body = JSON.parse(r.body);
+        return body.data !== undefined;
+      } catch {
+        return false;
+      }
+    },
+  });
+  teamsDuration.add(statsRes.timings.duration, { endpoint: "team_stats" });
+  teamsErrors.add(!statsOk);
+
+  sleep(0.5);
+
+  // 4. Team rankings
+  const rankingsRes = http.get(
+    `${BASE_URL}/api/team/${TEAM_ID}/rankings?season=2025`,
+    { tags: { name: "team_rankings" } }
+  );
+  const rankingsOk = check(rankingsRes, {
+    "team rankings: status 200": (r) => r.status === 200,
+    "team rankings: has data": (r) => {
+      try {
+        const body = JSON.parse(r.body);
+        return body.data !== undefined;
+      } catch {
+        return false;
+      }
+    },
+  });
+  teamsDuration.add(rankingsRes.timings.duration, { endpoint: "team_rankings" });
+  teamsErrors.add(!rankingsOk);
+
+  sleep(1);
+}

--- a/load-tests/smoke.js
+++ b/load-tests/smoke.js
@@ -1,0 +1,35 @@
+/**
+ * Smoke Test — 1 VU × 30s
+ *
+ * Purpose: fast sanity check that all endpoints respond correctly.
+ * Run this before load/stress to confirm the server is healthy.
+ *
+ * Usage:
+ *   k6 run load-tests/smoke.js
+ *   BASE_URL=https://your-server.com k6 run load-tests/smoke.js
+ *   make k6-smoke
+ */
+
+import dashboardScenario from "./scenarios/dashboard.js";
+import teamsScenario from "./scenarios/teams.js";
+import auditScenario from "./scenarios/audit.js";
+
+export const options = {
+  vus: 1,
+  duration: "30s",
+  thresholds: {
+    // All requests: <1% errors, p95 under 500ms
+    http_req_failed: ["rate<0.01"],
+    http_req_duration: ["p(95)<500", "p(99)<1000"],
+    // Per-flow error rates
+    dashboard_req_errors: ["rate<0.01"],
+    teams_req_errors: ["rate<0.01"],
+    audit_req_errors: ["rate<0.01"],
+  },
+};
+
+export default function () {
+  dashboardScenario();
+  teamsScenario();
+  auditScenario();
+}

--- a/load-tests/stress.js
+++ b/load-tests/stress.js
@@ -1,0 +1,48 @@
+/**
+ * Stress Test — find the degradation threshold
+ *
+ * Ramps beyond the expected baseline to identify at what concurrency level
+ * the server begins to degrade (p95 > 500ms or error rate climbs).
+ *
+ * Stages:
+ *   0 → 20 VUs over 1 min  (warm up at baseline)
+ *   20 → 50 VUs over 2 min (stress beyond baseline)
+ *   50 VUs held for 1 min  (observe behaviour at peak stress)
+ *   50 → 0 VUs over 1 min  (ramp down)
+ *   Total: ~5 minutes
+ *
+ * NOTE: Thresholds here are intentionally relaxed — the goal is observation,
+ * not pass/fail. Review the output summary to find where latency climbs.
+ *
+ * Usage:
+ *   k6 run load-tests/stress.js
+ *   BASE_URL=https://your-server.com k6 run load-tests/stress.js
+ *   make k6-stress
+ */
+
+import dashboardScenario from "./scenarios/dashboard.js";
+import teamsScenario from "./scenarios/teams.js";
+import auditScenario from "./scenarios/audit.js";
+
+export const options = {
+  stages: [
+    { duration: "1m", target: 20 }, // warm up at baseline
+    { duration: "2m", target: 50 }, // ramp to stress target
+    { duration: "1m", target: 50 }, // hold at stress peak
+    { duration: "1m", target: 0 }, // ramp down
+  ],
+  thresholds: {
+    // Relaxed thresholds — stress test is for observation, not blocking CI
+    http_req_failed: ["rate<0.05"], // alert if >5% errors under stress
+    http_req_duration: ["p(99)<3000"], // alert if p99 exceeds 3s
+    dashboard_req_errors: ["rate<0.05"],
+    teams_req_errors: ["rate<0.05"],
+    audit_req_errors: ["rate<0.05"],
+  },
+};
+
+export default function () {
+  dashboardScenario();
+  teamsScenario();
+  auditScenario();
+}


### PR DESCRIPTION
## Description
Establishes a k6 performance baseline ensuring the API handles 1000+ daily users without degradation.

## Changes
- `load-tests/scenarios/dashboard.js` — Rankings flow: `/health`, `/api/categories`, `/api/rankings` (PPG + RPG)
- `load-tests/scenarios/teams.js` — Teams flow: `/api/teams`, `/api/teams/abbr/BOS`, `/api/team/:id/stats`, `/api/team/:id/rankings`
- `load-tests/scenarios/audit.js` — Audit flow: `/api/audit/games` (all, collected, missing filters)
- `load-tests/smoke.js` — 1 VU × 30s sanity check
- `load-tests/load.js` — Baseline: ramp 0→20 VUs, hold 3 min (~5 min total)
- `load-tests/stress.js` — Degradation: ramp 0→50 VUs (~5 min total)
- `load-tests/README.md` — Usage guide, threshold rationale, load model math
- `Makefile` — Added `k6-smoke`, `k6-load`, `k6-stress` targets (supports `BASE_URL` override)
- `.github/workflows/load-test.yml` — Manual `workflow_dispatch` trigger with `base_url` input and `test_suite` selector; uploads results as artifact

## Thresholds (smoke + load)
- `http_req_failed` < 1%
- `http_req_duration` p95 < 500ms, p99 < 1000ms

## Local Usage
```bash
brew install k6
make k6-smoke   # quick sanity
make k6-load    # 1000 user baseline (~5 min)
make k6-stress  # degradation test (~5 min)

Closes #62 