### PR TITLE
Fix pg_dump path to use postgresql-18 binary explicitly

### DIFF
--- a/.github/workflows/backup-release.yml
+++ b/.github/workflows/backup-release.yml
@@ -30,7 +30,7 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
           FILENAME="nba_stats_$(date +%Y%m%d).dump"
-          pg_dump "$DATABASE_URL" -F c -f "$FILENAME"
+          /usr/lib/postgresql/18/bin/pg_dump "$DATABASE_URL" -F c -f "$FILENAME"
           echo "DUMP_FILE=$FILENAME" >> $GITHUB_ENV
 
       - name: Create GitHub Release and upload dump


### PR DESCRIPTION
The system default pg_dump (v16) takes precedence over the newly installed postgresql-client-18. Use the full path
/usr/lib/postgresql/18/bin/pg_dump to match Railway PostgreSQL 18.3.