### PR TITLE
Fix rate limits and add make dev target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: backend frontend services stop pipeline pipeline-prod fetch fetch-prod derive derive-prod backup backup-clean archive-season k6-smoke k6-load k6-stress
+.PHONY: dev backend frontend services stop pipeline pipeline-prod fetch fetch-prod derive derive-prod backup backup-clean archive-season k6-smoke k6-load k6-stress
 
 # ── Infrastructure ───────────────────────────────────────────────────────────
 services:
@@ -6,6 +6,11 @@ services:
 	brew services start redis
 
 # ── Application ──────────────────────────────────────────────────────────────
+dev:
+	$(MAKE) services
+	cd backend && npm run dev &
+	cd frontend && pnpm dev
+
 backend:
 	cd backend && npm run dev
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ make pipeline   # fetch → derive team stats → compute rankings → flush cac
 ### 5. Start the app
 
 ```bash
-make   # starts backend (port 5001) + frontend (port 3000)
+make dev   # starts services + backend (port 5001) + frontend (port 3000)
 ```
 
 ---
@@ -142,7 +142,7 @@ DATABASE_URL=postgresql://...   # from Railway dashboard
 
 | Target          | Description                              |
 | --------------- | ---------------------------------------- |
-| `make`          | Start backend + frontend dev servers     |
+| `make dev`      | Start services + backend + frontend      |
 | `make backend`  | Start backend only (nodemon)             |
 | `make frontend` | Start frontend only (Vite)               |
 | `make services` | Start PostgreSQL 16 + Redis via Homebrew |

--- a/backend/src/middleware/rateLimiter.js
+++ b/backend/src/middleware/rateLimiter.js
@@ -1,43 +1,47 @@
 const rateLimit = require("express-rate-limit");
 
+const isDev = process.env.NODE_ENV === "development";
+
 /**
  * Standard rate limiter for general API endpoints
- * 30 requests per 15 minutes per IP address
+ * 200 requests per 15 minutes per IP address
+ * Disabled in development to avoid 429s during local browsing
  */
 const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 30, // limit each IP to 30 requests per windowMs
+  max: 200,
   message: "Too many requests from this IP address, please try again after 15 minutes",
   standardHeaders: true, // Return rate limit info in the RateLimit-* headers
   legacyHeaders: false, // Disable the X-RateLimit-* headers
-  skip: (req) => {
-    // Skip rate limiting for health check endpoint
-    return req.path === "/health";
-  },
+  skip: (req) => isDev || req.path === "/health",
 });
 
 /**
- * Strict rate limiter for rankings endpoints
- * 15 requests per 15 minutes per IP address (more expensive database queries)
+ * Rate limiter for rankings endpoints
+ * 150 requests per 15 minutes per IP address
+ * Disabled in development
  */
 const rankingsLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 15, // limit each IP to 15 requests per windowMs
+  max: 150,
   message: "Too many ranking requests from this IP, please try again after 15 minutes",
   standardHeaders: true,
   legacyHeaders: false,
+  skip: () => isDev,
 });
 
 /**
- * Very strict rate limiter for team stats endpoints
- * 20 requests per 15 minutes per IP address
+ * Rate limiter for team stats endpoints
+ * 150 requests per 15 minutes per IP address
+ * Disabled in development
  */
 const teamStatsLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 20, // limit each IP to 20 requests per windowMs
+  max: 150,
   message: "Too many team stats requests from this IP, please try again after 15 minutes",
   standardHeaders: true,
   legacyHeaders: false,
+  skip: () => isDev,
 });
 
 module.exports = {


### PR DESCRIPTION
- Raise rate limits to production-appropriate values for a public read-only sports stats site (200 req/15 min general, 150 req/15 min for rankings and team stats endpoints)
- Add skip: NODE_ENV=development to all three limiters to prevent 429 errors during local development browsing
- Add 'make dev' target: starts services + backgrounds backend + foregrounds frontend in one command
- Update README step 5 and Makefile reference table to use 'make dev'