### PR TITLE
Update data accuracy docs to reflect current backfill state - Issue #139

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,17 +292,19 @@ make uninstall-cron
 
 Stat rankings are computed from season averages across all collected games. A small number of games have permanently incomplete records in the NBA API:
 
-| Game ID      | Missing data source   | Affected columns                                                                                                                                                                                                                       |
-| ------------ | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `0022500259` | BoxScoreSummaryV3 DF7 | `biggest_lead`, `bench_points`, `lead_changes`, `times_tied`, `biggest_scoring_run`, `pts_from_tov`                                                                                                                                    |
-| `0022500260` | BoxScoreSummaryV3 DF7 | same                                                                                                                                                                                                                                   |
-| `0022500261` | BoxScoreSummaryV3 DF7 | same                                                                                                                                                                                                                                   |
-| `0022500265` | BoxScoreSummaryV3 DF7 | same                                                                                                                                                                                                                                   |
-| `0022500603` | BoxScoreAdvancedV3    | `dreb_pct`, `reb_pct`, `oreb_pct`, `tm_tov_pct`, `e_tov_pct`, `ast_to_tov`, `ast_pct`, `ast_ratio`, `pace_per40`, `pie`, `poss`, `e_ortg`, `e_drtg`, `e_net_rtg`, `e_pace`, `opp_efg_pct`, `opp_tov_pct`, `opp_ft_rate`, `e_usage_pct` |
+| Game ID      | Missing data source       | Affected columns                                                                                                                                                                                                                                                            |
+| ------------ | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `0022500259` | BoxScoreSummaryV3 DF7     | `biggest_lead`, `bench_points`, `lead_changes`, `times_tied`, `biggest_scoring_run`, `pts_from_tov`                                                                                                                                                                         |
+| `0022500260` | BoxScoreSummaryV3 DF7     | same                                                                                                                                                                                                                                                                        |
+| `0022500261` | BoxScoreSummaryV3 DF7     | same                                                                                                                                                                                                                                                                        |
+| `0022500265` | BoxScoreSummaryV3 DF7     | same                                                                                                                                                                                                                                                                        |
+| `0022501026` | BoxScorePlayerTrackV3 DF1 | `distance`, `touches`, `passes`, `reb_chances_off`, `reb_chances_def`, `reb_chances_total`, `secondary_ast`, `ft_ast`, `contested_fgm`, `contested_fga`, `contested_fg_pct`, `uncontested_fgm`, `uncontested_fga`, `uncontested_fg_pct`, `dar_fgm`, `dar_fga`, `dar_fg_pct` |
+| `0022501035` | BoxScorePlayerTrackV3 DF1 | same                                                                                                                                                                                                                                                                        |
+| `0022501036` | BoxScorePlayerTrackV3 DF1 | same                                                                                                                                                                                                                                                                        |
 
-**Cause:** These games appear to have incomplete records in the NBA API — likely postponed or rescheduled games that were never fully recorded. All 5 failed on every retry attempt.
+**Cause:** These games appear to have incomplete records in the NBA API — likely postponed or rescheduled games that were never fully recorded. All 7 failed on every retry attempt.
 
-**Impact:** Negligible. `COALESCE` treats missing values as 0 in season averages. With 70+ games per team in a season, 5 missing games shift any affected average by less than 0.1%.
+**Impact:** Negligible. `COALESCE` treats missing values as 0 in season averages. With 70+ games per team in a season, 7 missing games shift any affected average by less than 0.1%.
 
 ---
 

--- a/frontend/src/pages/AboutPage.jsx
+++ b/frontend/src/pages/AboutPage.jsx
@@ -33,12 +33,22 @@ export function AboutPage() {
             <div className="bg-warning/10 p-4 rounded-lg border border-warning">
               <h3 className="font-semibold text-warning mb-2">⚠️ Known Data Gaps</h3>
               <p className="text-sm mb-3">
-                Some games may be missing from the database due to API availability limitations:
+                7 games have permanently incomplete records in the NBA Stats API and are excluded
+                from certain stat averages:
               </p>
               <ul className="list-disc list-inside space-y-1 text-sm ml-2">
-                <li>Early season games (before backfill completion)</li>
-                <li>Games affected by stats.nba.com API rate limiting during initial data fetch</li>
+                <li>
+                  4 games missing BoxScoreSummaryV3 data (bench points, lead changes, pts from
+                  turnovers)
+                </li>
+                <li>
+                  3 games missing BoxScorePlayerTrackV3 data (distance, touches, contested shots)
+                </li>
               </ul>
+              <p className="text-sm mt-2">
+                Impact is negligible — missing values are treated as 0 and represent less than 0.1%
+                of each team&apos;s season average.
+              </p>
             </div>
 
             <div>


### PR DESCRIPTION
## Summary

The "Data Accuracy & Completeness" section in the README and the "Known Data Gaps" section in the About page both contained stale information after the most recent backfill and production sync.

## What was outdated

**README.md**
- Listed game `0022500603` as missing BoxScoreAdvancedV3 data — this game was fully backfilled when the production DB was restored; the row should have been removed.
- Did not reflect the 3 newly-identified games missing `BoxScorePlayerTrackV3` data discovered during the backfill completeness audit.
- Impact blurb said "All 5 failed" — should be 7 (4 SummaryV3 + 3 PlayerTrackV3).

**AboutPage.jsx**
- "Known Data Gaps" section used generic placeholder bullets ("Early season games…", "API rate limiting…") that were never updated to reflect the actual missing games.

## Changes

- **README.md**: Removed `0022500603` row (now fully populated). Added 3 `BoxScorePlayerTrackV3` rows for games `0022501026`, `0022501035`, `0022501036` with their 17 affected columns. Updated impact text to "All 7 failed."
- **frontend/src/pages/AboutPage.jsx**: Replaced generic bullets with accurate counts — 4 games missing SummaryV3 data and 3 games missing PlayerTrackV3 data — with specific stat categories described.

## Context

Missing game IDs (permanently unavailable in the NBA Stats API):
- **BoxScoreSummaryV3**: `0022500259`, `0022500260`, `0022500261`, `0022500265`
- **BoxScorePlayerTrackV3**: `0022501026`, `0022501035`, `0022501036`

All 7 were retried multiple times. `COALESCE` handles nulls in averages — impact on season stats is < 0.1%.

Closes #139
