### PR TITLE
Rankings dropdown: option groups, Surprise Me button, remove duplicate BENCH_PTS - Issue #141

### DIFF
--- a/backend/scripts/derive_rankings.py
+++ b/backend/scripts/derive_rankings.py
@@ -101,7 +101,6 @@ STAT_CATEGORIES = [
 
     # BoxScoreSummaryV3 extras
     ('BIG_LEAD',   'biggest_lead',        'DESC'),  # Biggest Lead (avg) - higher is better
-    ('BENCH_PTS',  'bench_points',        'DESC'),  # Bench Points Per Game - higher is better
     ('LEAD_CHG',   'lead_changes',        'DESC'),  # Lead Changes Per Game - higher is better
     ('TIMES_TIED', 'times_tied',          'DESC'),  # Times Tied Per Game
     ('BIG_RUN',    'biggest_scoring_run', 'DESC'),  # Biggest Scoring Run (avg) - higher is better

--- a/backend/src/services/statProcessor.js
+++ b/backend/src/services/statProcessor.js
@@ -76,7 +76,6 @@ const STAT_CATEGORIES = {
 
   // BoxScoreSummaryV3 extras
   BIG_LEAD: { label: "Biggest Lead (avg)", index: "BIG_LEAD", lower: false },
-  BENCH_PTS: { label: "Bench Points Per Game", index: "BENCH_PTS", lower: false },
   LEAD_CHG: { label: "Lead Changes Per Game", index: "LEAD_CHG", lower: false },
   TIMES_TIED: { label: "Times Tied Per Game", index: "TIMES_TIED", lower: false },
   BIG_RUN: { label: "Biggest Scoring Run (avg)", index: "BIG_RUN", lower: false },

--- a/frontend/src/pages/RankingsPage.jsx
+++ b/frontend/src/pages/RankingsPage.jsx
@@ -3,12 +3,192 @@ import { RankingsGrid } from "../components/RankingsGrid";
 import { Top5Showcase } from "../components/Top5Showcase";
 import { useCategories, useRankings } from "../hooks/useApi";
 
+const CATEGORY_GROUPS = [
+  {
+    label: "Basic",
+    codes: [
+      "PPG",
+      "FG_PG",
+      "FGA_PG",
+      "FG%",
+      "THREE_PG",
+      "3P%",
+      "FT%",
+      "RPG",
+      "APG",
+      "SPG",
+      "BPG",
+      "TPG",
+      "PFPG",
+    ],
+  },
+  {
+    label: "Offensive",
+    codes: [
+      "PTS_2ND_CHC",
+      "AST%",
+      "AST_RATIO",
+      "AST_TOV",
+      "PCT_AST_2PM",
+      "PCT_AST_3PM",
+      "PCT_AST_FGM",
+      "BIG_LEAD",
+      "BIG_RUN",
+      "EFG%",
+      "E_ORTG",
+      "FAST_BRK",
+      "PCT_FGA_2PT",
+      "PCT_FGA_3PT",
+      "FOULS_DRAWN",
+      "FT_AST",
+      "LEAD_CHG",
+      "NET_RTG",
+      "LOOSE_BALLS_O",
+      "BOX_OUTS_O",
+      "ORTG",
+      "ORB%",
+      "REB_CHANCES_OFF",
+      "ORPG",
+      "PACE",
+      "PACE40",
+      "PASSES",
+      "PIE",
+      "PM",
+      "PCT_PTS_2PT",
+      "PCT_PTS_2PT_MR",
+      "PCT_PTS_3PT",
+      "PCT_PTS_FB",
+      "PCT_PTS_FT",
+      "PCT_PTS_PAINT",
+      "PCT_PTS_OFF_TOV",
+      "PTS_PAINT",
+      "PTS_OFF_TO",
+      "POSS",
+      "Q1_PTS",
+      "Q2_PTS",
+      "Q3_PTS",
+      "Q4_PTS",
+      "SCR_AST_PTS",
+      "SCR_AST",
+      "SECONDARY_AST",
+      "TOV_TOTAL",
+      "TOUCHES",
+      "TS%",
+      "TOV%",
+      "TOV_RATIO",
+      "PCT_UAST_2PM",
+      "PCT_UAST_3PM",
+      "PCT_UAST_FGM",
+      "USG%",
+    ],
+  },
+  {
+    label: "Defensive",
+    codes: [
+      "BLK_AGT",
+      "BOX_OUT_PREB",
+      "BOX_OUT_TREB",
+      "BOX_OUTS",
+      "CHARGES",
+      "CONTESTED_2PT",
+      "CONTESTED_3PT",
+      "CONTESTED_FG%",
+      "CONTESTED_FGM",
+      "CONTESTED_FGA",
+      "CONTESTED",
+      "LOOSE_BALLS_D",
+      "DAR_FG%",
+      "DAR_FGM",
+      "DAR_FGA",
+      "BOX_OUTS_D",
+      "DRTG",
+      "DRB%",
+      "REB_CHANCES_DEF",
+      "DRPG",
+      "DEFLECT",
+      "E_DRTG",
+      "LOOSE_BALLS",
+      "OPP_2ND_CHC",
+      "OPP_FBRK",
+      "OPP_PAINT",
+      "OPP_PTS_OFF_TO",
+      "TRB%",
+      "REB_CHANCES_TOT",
+      "UNCONTESTED_FG%",
+      "UNCONTESTED_FGM",
+      "UNCONTESTED_FGA",
+    ],
+  },
+  {
+    label: "Bench",
+    codes: [
+      "BENCH_3P%",
+      "BENCH_3P",
+      "BENCH_3PA",
+      "BENCH_APG",
+      "BENCH_BPG",
+      "BENCH_DREB",
+      "BENCH_FG",
+      "BENCH_FGA",
+      "BENCH_FG%",
+      "BENCH_PF",
+      "BENCH_FT%",
+      "BENCH_FT",
+      "BENCH_FTA",
+      "BENCH_OREB",
+      "BENCH_PPG",
+      "BENCH_RPG",
+      "BENCH_SPG",
+      "BENCH_TOV",
+    ],
+  },
+  {
+    label: "Starters",
+    codes: [
+      "STARTERS_3P%",
+      "STARTERS_3P",
+      "STARTERS_3PA",
+      "STARTERS_APG",
+      "STARTERS_BPG",
+      "STARTERS_DREB",
+      "STARTERS_FG",
+      "STARTERS_FGA",
+      "STARTERS_FG%",
+      "STARTERS_PF",
+      "STARTERS_FT%",
+      "STARTERS_FT",
+      "STARTERS_FTA",
+      "STARTERS_OREB",
+      "STARTERS_PPG",
+      "STARTERS_RPG",
+      "STARTERS_SPG",
+      "STARTERS_TOV",
+    ],
+  },
+  {
+    label: "Misc",
+    codes: [
+      "ATTEND",
+      "DURATION",
+      "DISTANCE",
+      "E_NET_RTG",
+      "E_PACE",
+      "REB_TEAM",
+      "TOV_TEAM",
+      "TIMES_TIED",
+    ],
+  },
+];
+
 export function RankingsPage() {
   const [selectedCategory, setSelectedCategory] = useState("PPG");
   const [shouldAnimate, setShouldAnimate] = useState(true);
   const season = import.meta.env.VITE_CURRENT_SEASON || "2025";
   const { data: categories, isLoading: categoriesLoading } = useCategories();
   const { data: rankings } = useRankings(selectedCategory, season);
+
+  // Build a code→label lookup for optgroup rendering
+  const categoryMap = new Map((categories ?? []).map((cat) => [cat.code, cat.label]));
 
   // Get the label for the selected category
   const selectedCategoryLabel =
@@ -29,6 +209,13 @@ export function RankingsPage() {
     setSelectedCategory(newCategory);
   };
 
+  const handleSurpriseMe = () => {
+    const allCodes = categories?.map((cat) => cat.code) ?? [];
+    if (allCodes.length === 0) return;
+    const randomCode = allCodes[Math.floor(Math.random() * allCodes.length)];
+    handleCategoryChange(randomCode);
+  };
+
   return (
     <>
       {/* Controls Section */}
@@ -36,30 +223,43 @@ export function RankingsPage() {
         <div className="card-body">
           <h2 className="card-title text-xl">Filters</h2>
 
-          <div className="grid grid-cols-1 gap-4">
-            {/* Category Selector */}
-            <div className="form-control">
-              <label className="label">
-                <span className="label-text font-semibold">Stat Category</span>
-              </label>
-              <select
-                className="select select-bordered"
-                value={selectedCategory}
-                onChange={(e) => handleCategoryChange(e.target.value)}
+          {/* Category Selector */}
+          <div className="flex flex-col gap-2">
+            <span className="text-sm font-semibold">Stat Category</span>
+            <select
+              className="select select-bordered w-full max-w-sm"
+              value={selectedCategory}
+              onChange={(e) => handleCategoryChange(e.target.value)}
+              disabled={categoriesLoading}
+            >
+              {categoriesLoading ? (
+                <option>Loading categories...</option>
+              ) : (
+                CATEGORY_GROUPS.map((group) => {
+                  const opts = group.codes
+                    .filter((code) => categoryMap.has(code))
+                    .map((code) => (
+                      <option key={code} value={code}>
+                        {categoryMap.get(code)}
+                      </option>
+                    ));
+                  return opts.length > 0 ? (
+                    <optgroup key={group.label} label={group.label}>
+                      {opts}
+                    </optgroup>
+                  ) : null;
+                })
+              )}
+            </select>
+            <div className="mt-1">
+              <button
+                type="button"
+                className="btn btn-secondary btn-sm"
+                onClick={handleSurpriseMe}
                 disabled={categoriesLoading}
               >
-                {categoriesLoading ? (
-                  <option>Loading categories...</option>
-                ) : (
-                  [...(categories ?? [])]
-                    .sort((a, b) => a.label.localeCompare(b.label))
-                    .map((cat) => (
-                      <option key={cat.code} value={cat.code}>
-                        {cat.label}
-                      </option>
-                    ))
-                )}
-              </select>
+                🎲 Surprise me
+              </button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Addresses all items from issue #141.

## Changes

- **Remove duplicate "Bench Points Per Game"** — `BENCH_PTS` (SummaryV3, 8 rows missing) removed from `statProcessor.js` and `derive_rankings.py`. `BENCH_PPG` (TraditionalV3, 100% complete) is the canonical entry.
- **Option groups in stat category dropdown** — 6 `<optgroup>` sections: Basic, Offensive, Defensive, Bench, Starters, Misc. All 114 remaining categories mapped to their group.
- **Spacing fix** — replaced DaisyUI `form-control`/`label` pattern with explicit `flex flex-col gap-2` layout so the label, dropdown, and button stack cleanly with visible separation.
- **"Surprise me" button** — picks a random stat category from the full list; uses `btn-secondary btn-sm` styling, placed directly below the dropdown.

Closes #141
