### PR TITLE
Fix BENCH_PTS showing as raw label in TeamPage

### DIFF
--- a/backend/migrations/010_cleanup_stale_rankings.js
+++ b/backend/migrations/010_cleanup_stale_rankings.js
@@ -1,0 +1,41 @@
+const db = require("../src/db/postgresClient");
+
+// ----------------------------------------------------------------------------
+// Migration 010: Delete stale stat_rankings rows with renamed category codes
+//
+// When derive_rankings.py category codes are renamed, old rows remain in
+// stat_rankings because the upsert key is (team_id, stat_category, season).
+// Old rows are never overwritten — they accumulate as orphans that have no
+// matching label in statProcessor.js STAT_CATEGORIES, causing the raw code
+// (e.g. "BENCH_PTS") to appear in the UI instead of a human-readable label.
+//
+// Known renamed codes:
+//   BENCH_PTS → replaced by BENCH_PPG (bench_pts column, same data)
+//
+// ROLLBACK: None needed — data will be re-derived on next `make derive-prod`
+//           using the current correct codes.
+// ----------------------------------------------------------------------------
+
+async function run() {
+  try {
+    console.log("Running migration: 010_cleanup_stale_rankings");
+
+    const result = await db.query(`
+      DELETE FROM stat_rankings
+      WHERE stat_category = 'BENCH_PTS'
+    `);
+
+    console.log(
+      `✅ Migration 010 complete: deleted ${result.rowCount} stale BENCH_PTS ranking rows`
+    );
+  } catch (err) {
+    console.error("❌ Migration 010 failed:", err.message);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  run().then(() => process.exit(0));
+}
+
+module.exports = run;


### PR DESCRIPTION
The TeamPage was showing the raw code `BENCH_PTS` instead of a human-readable label (e.g. "Bench Points Per Game") in the medal banners and rankings table.

## Root Cause

`derive_rankings.py` originally used `BENCH_PTS` as the stat category code, then it was renamed to `BENCH_PPG`. The upsert in `derive_rankings.py` uses `(team_id, stat_category, season)` as the conflict key — so old `BENCH_PTS` rows were never overwritten, they accumulated as orphans. Since `statProcessor.js` has no entry for `BENCH_PTS`, the frontend fell back to displaying the raw code.

## Changes

- **`backend/migrations/010_cleanup_stale_rankings.js`**: Deletes the 30 stale `BENCH_PTS` rows from `stat_rankings` (one per team). Applied locally (deleted 30 rows) and to production via `make migrate-prod MIGRATION=010_cleanup_stale_rankings`.
