### PR TITLE
Unify season config: centralize CURRENT_SEASON constant

### DIFF
--- a/.github/workflows/nba-pipeline.yml
+++ b/.github/workflows/nba-pipeline.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           REDIS_URL: ${{ secrets.REDIS_URL }}
-          CURRENT_SEASON: ${{ secrets.CURRENT_SEASON }}
+          CURRENT_SEASON: ${{ vars.CURRENT_SEASON }}
         run: python scripts/derive_team_stats.py
 
       - name: Derive rankings and clear cache
@@ -40,5 +40,5 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           REDIS_URL: ${{ secrets.REDIS_URL }}
-          CURRENT_SEASON: ${{ secrets.CURRENT_SEASON }}
+          CURRENT_SEASON: ${{ vars.CURRENT_SEASON }}
         run: python scripts/derive_rankings.py

--- a/.github/workflows/season-archive.yml
+++ b/.github/workflows/season-archive.yml
@@ -36,14 +36,14 @@ jobs:
         working-directory: backend
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          ARCHIVE_SEASON: ${{ secrets.CURRENT_SEASON }}
+          ARCHIVE_SEASON: ${{ vars.CURRENT_SEASON }}
           ARCHIVE_DIR: ../season_archive
         run: python scripts/archive_season.py
 
       - name: Run pg_dump (full DB snapshot)
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          CURRENT_SEASON: ${{ secrets.CURRENT_SEASON }}
+          CURRENT_SEASON: ${{ vars.CURRENT_SEASON }}
         run: |
           DUMP_FILE="nba_stats_season_${CURRENT_SEASON}.dump"
           /usr/lib/postgresql/18/bin/pg_dump "$DATABASE_URL" -F c -f "$DUMP_FILE"

--- a/frontend/src/components/AuditTab.jsx
+++ b/frontend/src/components/AuditTab.jsx
@@ -3,8 +3,7 @@ import { apiClient } from "../hooks/useApi";
 import GameStatsRow from "./GameStatsRow";
 
 export function AuditTab({ season }) {
-  // Only 2025-26 season data available
-  const auditSeason = "2025";
+  const auditSeason = season;
   const [stats, setStats] = useState(null);
   const [games, setGames] = useState([]);
   const [pagination, setPagination] = useState(null);

--- a/frontend/src/components/DidYouKnow.jsx
+++ b/frontend/src/components/DidYouKnow.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
-import { useRandomFacts, useAllTeams } from "../hooks/useApi";
+import { useRandomFacts, useAllTeams, CURRENT_SEASON } from "../hooks/useApi";
 
 const TEAM_ID_TO_ABBR = {
   1610612737: "ATL",
@@ -59,7 +59,7 @@ function getCardColor(teamId, allTeams) {
 }
 
 export function DidYouKnow() {
-  const season = import.meta.env.VITE_CURRENT_SEASON || "2025";
+  const season = CURRENT_SEASON;
   const { data: facts } = useRandomFacts(10, season);
   const { data: allTeams } = useAllTeams();
   const [activeIndex, setActiveIndex] = useState(0);

--- a/frontend/src/components/RankingsGrid.jsx
+++ b/frontend/src/components/RankingsGrid.jsx
@@ -35,7 +35,7 @@ const TEAM_ID_TO_ABBR = {
   1610612766: "CHA",
 };
 
-export function RankingsGrid({ category, season = "2025" }) {
+export function RankingsGrid({ category, season }) {
   const { data, isLoading, error } = useRankings(category, season);
   const { data: allTeams } = useAllTeams();
 

--- a/frontend/src/components/__tests__/AuditTab.test.jsx
+++ b/frontend/src/components/__tests__/AuditTab.test.jsx
@@ -237,7 +237,7 @@ describe("AuditTab Component", () => {
   it("should make API call with correct season", () => {
     render(<AuditTab season="2024" />);
 
-    expect(apiClient.get).toHaveBeenCalledWith(expect.stringContaining("season=2025"));
+    expect(apiClient.get).toHaveBeenCalledWith(expect.stringContaining("season=2024"));
   });
 
   it("should have progress bar for collection rate", async () => {

--- a/frontend/src/components/__tests__/RankingsGrid.test.jsx
+++ b/frontend/src/components/__tests__/RankingsGrid.test.jsx
@@ -292,14 +292,14 @@ describe("RankingsGrid Component", () => {
     expect(links.some((link) => link.href.includes("/team/BOS"))).toBe(true);
   });
 
-  it("should use default season prop of 2025", () => {
+  it("should pass season prop to useRankings", () => {
     render(
       <BrowserRouter>
         <RankingsGrid category="PPG" />
       </BrowserRouter>
     );
 
-    expect(useRankings).toHaveBeenCalledWith("PPG", "2025");
+    expect(useRankings).toHaveBeenCalledWith("PPG", undefined);
   });
 
   it("should use custom season prop when provided", () => {

--- a/frontend/src/hooks/useApi.js
+++ b/frontend/src/hooks/useApi.js
@@ -2,13 +2,14 @@ import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || "/api";
+const CURRENT_SEASON = import.meta.env.VITE_CURRENT_SEASON || "2025";
 
 const apiClient = axios.create({
   baseURL: API_BASE_URL,
   timeout: 10000,
 });
 
-export { apiClient, API_BASE_URL };
+export { apiClient, API_BASE_URL, CURRENT_SEASON };
 
 // Hook for fetching available categories
 export function useCategories() {
@@ -24,7 +25,7 @@ export function useCategories() {
 }
 
 // Hook for fetching rankings for a specific category
-export function useRankings(category, season = "2025") {
+export function useRankings(category, season = CURRENT_SEASON) {
   return useQuery({
     queryKey: ["rankings", category, season],
     queryFn: async () => {
@@ -40,7 +41,7 @@ export function useRankings(category, season = "2025") {
 }
 
 // Hook for fetching team stats
-export function useTeamStats(teamId, season = "2025") {
+export function useTeamStats(teamId, season = CURRENT_SEASON) {
   return useQuery({
     queryKey: ["teamStats", teamId, season],
     queryFn: async () => {
@@ -56,7 +57,7 @@ export function useTeamStats(teamId, season = "2025") {
 }
 
 // Hook for fetching team rankings
-export function useTeamRankings(teamId, season = "2025") {
+export function useTeamRankings(teamId, season = CURRENT_SEASON) {
   return useQuery({
     queryKey: ["teamRankings", teamId, season],
     queryFn: async () => {
@@ -99,7 +100,7 @@ export function useTeamByAbbreviation(abbreviation) {
 }
 
 // Hook for fetching random top-5 facts
-export function useRandomFacts(count = 10, season = "2025") {
+export function useRandomFacts(count = 10, season = CURRENT_SEASON) {
   return useQuery({
     queryKey: ["randomFacts", count, season],
     queryFn: async () => {

--- a/frontend/src/pages/AuditPage.jsx
+++ b/frontend/src/pages/AuditPage.jsx
@@ -1,7 +1,6 @@
 import { AuditTab } from "../components/AuditTab";
+import { CURRENT_SEASON } from "../hooks/useApi";
 
 export function AuditPage() {
-  const season = "2025"; // Only 2025-26 season available
-
-  return <AuditTab season={season} />;
+  return <AuditTab season={CURRENT_SEASON} />;
 }

--- a/frontend/src/pages/RankingsPage.jsx
+++ b/frontend/src/pages/RankingsPage.jsx
@@ -2,7 +2,7 @@ import { useState, useRef } from "react";
 import { DidYouKnow } from "../components/DidYouKnow";
 import { RankingsGrid } from "../components/RankingsGrid";
 import { Top5Showcase } from "../components/Top5Showcase";
-import { useCategories, useRankings } from "../hooks/useApi";
+import { useCategories, useRankings, CURRENT_SEASON } from "../hooks/useApi";
 
 const CATEGORY_GROUPS = [
   {
@@ -187,7 +187,7 @@ const CATEGORY_GROUPS = [
 export function RankingsPage() {
   const [selectedCategory, setSelectedCategory] = useState("PPG");
   const [shouldAnimate, setShouldAnimate] = useState(true);
-  const season = import.meta.env.VITE_CURRENT_SEASON || "2025";
+  const season = CURRENT_SEASON;
   const { data: categories, isLoading: categoriesLoading } = useCategories();
   const { data: rankings } = useRankings(selectedCategory, season);
 

--- a/frontend/src/pages/TeamPage.jsx
+++ b/frontend/src/pages/TeamPage.jsx
@@ -5,6 +5,7 @@ import {
   useTeamStats,
   useTeamRankings,
   useCategories,
+  CURRENT_SEASON,
 } from "../hooks/useApi";
 import { formatStatValue, formatPercentageStat } from "../utils/statFormatter";
 
@@ -21,8 +22,8 @@ const getFormattedCategoryLabel = (label) => {
 export function TeamPage() {
   const { abbreviation } = useParams();
   const { data: team, isLoading: teamLoading } = useTeamByAbbreviation(abbreviation);
-  const { data: stats, isLoading: statsLoading } = useTeamStats(team?.team_id, "2025");
-  const { data: rankings, isLoading: rankingsLoading } = useTeamRankings(team?.team_id, "2025");
+  const { data: stats, isLoading: statsLoading } = useTeamStats(team?.team_id);
+  const { data: rankings, isLoading: rankingsLoading } = useTeamRankings(team?.team_id);
   const { data: categories } = useCategories();
 
   // Sorting state - default to "category" ascending (A->Z)
@@ -307,7 +308,7 @@ export function TeamPage() {
       {/* Stats Rankings Table */}
       <div className="card bg-base-200 shadow-md">
         <div className="card-body">
-          <h2 className="card-title mb-4">Season Stats & Rankings (2025)</h2>
+          <h2 className="card-title mb-4">Season Stats & Rankings ({CURRENT_SEASON})</h2>
 
           <div className="overflow-x-auto">
             <table className="table table-zebra w-full">


### PR DESCRIPTION
Centralizes all hardcoded "2025" season references in the frontend to a single `CURRENT_SEASON` constant exported from `useApi.js`, backed by the `VITE_CURRENT_SEASON` env var. Also switches GitHub Actions workflows from `secrets.CURRENT_SEASON` to `vars.CURRENT_SEASON` since the season value is not sensitive data.

## Changes
- Added `CURRENT_SEASON` constant in `useApi.js` (reads `VITE_CURRENT_SEASON` env var with `"2025"` fallback)
- Updated all hook defaults (`useRankings`, `useTeamStats`, `useTeamRankings`, `useRandomFacts`) to use `CURRENT_SEASON`
- Updated `RankingsPage`, `DidYouKnow`, `TeamPage`, `AuditPage`, `AuditTab`, `RankingsGrid` to import and use `CURRENT_SEASON` instead of hardcoded values
- Switched `nba-pipeline.yml` and `season-archive.yml` from `secrets.CURRENT_SEASON` to `vars.CURRENT_SEASON`
- Updated tests to match new behavior (no default season prop on `RankingsGrid`, fixed `AuditTab` season assertion)

## Note
After merging, create a GitHub repository **variable** (not secret) named `CURRENT_SEASON` with value `2025` in Settings → Secrets and variables → Actions → Variables tab.
