### PR TITLE
Add Classic and Challenge game modes

### DIFF
--- a/frontend/e2e/game.spec.js
+++ b/frontend/e2e/game.spec.js
@@ -5,22 +5,23 @@ test.beforeEach(async ({ page }) => {
   await setupApiMocks(page);
 });
 
-test("game page shows intro screen with Play button", async ({ page }) => {
+test("game page shows intro screen with Classic and Challenge buttons", async ({ page }) => {
   await page.goto("/game");
 
   await expect(page.getByText("NBA Top Five In Guesser")).toBeVisible();
   await expect(page.getByText(/Test your NBA knowledge/)).toBeVisible();
-  await expect(page.getByRole("button", { name: "Play" })).toBeVisible();
+  await expect(page.getByText("Play Classic Mode")).toBeVisible();
+  await expect(page.getByText("Play Challenge Mode")).toBeVisible();
 });
 
-test("game page loads and shows a question after clicking Play", async ({ page }) => {
+test("game page loads and shows a question after clicking Classic", async ({ page }) => {
   await page.goto("/game");
 
-  // Click Play on intro screen
-  await page.getByRole("button", { name: "Play" }).click();
+  // Click Classic to start game
+  await page.getByRole("button", { name: /Classic/ }).click();
 
-  // Should show the question text
-  await expect(page.getByText(/Which team is ranked/)).toBeVisible({ timeout: 10000 });
+  // Classic mode question text
+  await expect(page.getByText(/Which team is in the/)).toBeVisible({ timeout: 10000 });
 
   // Should show 3 choice buttons
   const choiceButtons = page.locator(".card-body button");
@@ -29,9 +30,9 @@ test("game page loads and shows a question after clicking Play", async ({ page }
 
 test("clicking correct answer shows Correct feedback", async ({ page }) => {
   await page.goto("/game");
-  await page.getByRole("button", { name: "Play" }).click();
+  await page.getByRole("button", { name: /Classic/ }).click();
 
-  await expect(page.getByText(/Which team is ranked/)).toBeVisible({ timeout: 10000 });
+  await expect(page.getByText(/Which team is in the/)).toBeVisible({ timeout: 10000 });
 
   // The question asks about rank 1, 2, or 3 in PPG or RPG
   // Find the correct team by checking who is highlighted after clicking
@@ -57,11 +58,11 @@ test("game nav link navigates to game page", async ({ page }) => {
   await expect(page).toHaveURL(/\/game/);
 });
 
-test("game over shows Play Again button", async ({ page }) => {
+test("game over shows Classic and Challenge buttons", async ({ page }) => {
   await page.goto("/game");
-  await page.getByRole("button", { name: "Play" }).click();
+  await page.getByRole("button", { name: /Classic/ }).click();
 
-  await expect(page.getByText(/Which team is ranked/)).toBeVisible({ timeout: 10000 });
+  await expect(page.getByText(/Which team is in the/)).toBeVisible({ timeout: 10000 });
 
   // Keep clicking wrong answers until game over
   // Click buttons until we get "Wrong!" then wait for Game Over
@@ -86,7 +87,8 @@ test("game over shows Play Again button", async ({ page }) => {
   if (isWrong) {
     // Wait for game over screen
     await expect(page.getByText("Game Over!")).toBeVisible({ timeout: 5000 });
-    await expect(page.getByRole("button", { name: "Play Again" })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Classic/ })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Challenge/ })).toBeVisible();
     await expect(page.getByRole("link", { name: "View all Rankings" })).toBeVisible();
     await expect(page.getByRole("link", { name: "View by Teams" })).toBeVisible();
   } else {

--- a/frontend/src/hooks/useGameEngine.js
+++ b/frontend/src/hooks/useGameEngine.js
@@ -23,19 +23,22 @@ const BASIC_CODES = [
 
 const ORDINAL = ["", "1st", "2nd", "3rd", "4th", "5th"];
 
-const HIGH_SCORE_KEY = "topfivin-game-highscore";
+const HIGH_SCORE_KEYS = {
+  classic: "topfivin-game-highscore-classic",
+  challenge: "topfivin-game-highscore-challenge",
+};
 
-function getHighScore() {
+function getHighScore(mode) {
   try {
-    return parseInt(localStorage.getItem(HIGH_SCORE_KEY), 10) || 0;
+    return parseInt(localStorage.getItem(HIGH_SCORE_KEYS[mode]), 10) || 0;
   } catch {
     return 0;
   }
 }
 
-function saveHighScore(score) {
+function saveHighScore(mode, score) {
   try {
-    localStorage.setItem(HIGH_SCORE_KEY, String(score));
+    localStorage.setItem(HIGH_SCORE_KEYS[mode], String(score));
   } catch {
     // localStorage unavailable
   }
@@ -57,17 +60,26 @@ function shuffleArray(arr) {
 export function useGameEngine() {
   const { data: categories, isLoading: categoriesLoading } = useCategories();
 
+  const [gameMode, setGameMode] = useState("classic"); // classic | challenge
   const [gameState, setGameState] = useState("intro"); // intro | playing | correct | wrong | ended
   const [questionNumber, setQuestionNumber] = useState(0);
   const [score, setScore] = useState(0);
-  const [highScore, setHighScore] = useState(getHighScore);
+  const [highScore, setHighScore] = useState(() => getHighScore("classic"));
   const [currentQuestion, setCurrentQuestion] = useState(null);
   const [loading, setLoading] = useState(false);
   const [selectedTeamId, setSelectedTeamId] = useState(null);
 
+  const activeModeRef = useRef("classic");
   const autoAdvanceTimer = useRef(null);
   // Track mounted state to prevent state updates after unmount
   const mountedRef = useRef(true);
+
+  // Update high score when mode changes on intro screen
+  const handleSetGameMode = useCallback((mode) => {
+    setGameMode(mode);
+    setHighScore(getHighScore(mode));
+    activeModeRef.current = mode;
+  }, []);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -78,9 +90,10 @@ export function useGameEngine() {
   }, []);
 
   const generateQuestion = useCallback(
-    async (qNumber) => {
+    async (qNumber, mode) => {
       if (!categories || categories.length === 0) return;
 
+      const activeMode = mode || activeModeRef.current;
       setLoading(true);
       const maxAttempts = 10;
 
@@ -88,7 +101,6 @@ export function useGameEngine() {
         // Pick category based on difficulty ramp
         let pool;
         if (qNumber < 3) {
-          // First 3 questions: basic stats only, ranks 1-3
           pool = categories.filter((c) => BASIC_CODES.includes(c.code));
         } else {
           pool = categories;
@@ -97,8 +109,6 @@ export function useGameEngine() {
         if (pool.length === 0) pool = categories;
 
         const category = pickRandom(pool);
-        const maxRank = qNumber < 3 ? 3 : 5;
-        const targetRank = Math.floor(Math.random() * maxRank) + 1;
 
         try {
           const response = await apiClient.get("/rankings", {
@@ -108,19 +118,42 @@ export function useGameEngine() {
           const rankings = response.data?.rankings;
           if (!rankings || rankings.length === 0) continue;
 
-          // Find team at target rank
-          const correctTeam = rankings.find((r) => r.rank === targetRank);
-          if (!correctTeam) continue;
+          let correctTeam;
+          let targetRank;
+          let wrongPool;
 
-          // Check for ties — skip if another team shares the same rank
-          const teamsAtRank = rankings.filter((r) => r.rank === targetRank);
-          if (teamsAtRank.length > 1) continue;
+          if (activeMode === "classic") {
+            // Classic: pick a random team from top 5
+            const top5 = rankings.filter((r) => r.rank >= 1 && r.rank <= 5);
+            if (top5.length === 0) continue;
 
-          // Pick 2 wrong choices from teams ranked lower than the correct team
-          // and not within 2 ranks of the target rank
-          const wrongPool = rankings.filter(
-            (r) => r.rank > targetRank && Math.abs(r.rank - targetRank) > 2
-          );
+            correctTeam = pickRandom(top5);
+            targetRank = correctTeam.rank;
+
+            // Check for ties
+            const teamsAtRank = rankings.filter((r) => r.rank === targetRank);
+            if (teamsAtRank.length > 1) continue;
+
+            // Wrong choices: outside top 5, with >2 rank buffer from boundary
+            wrongPool = rankings.filter((r) => r.rank > 7);
+          } else {
+            // Challenge: guess specific rank (existing logic)
+            const maxRank = qNumber < 3 ? 3 : 5;
+            targetRank = Math.floor(Math.random() * maxRank) + 1;
+
+            correctTeam = rankings.find((r) => r.rank === targetRank);
+            if (!correctTeam) continue;
+
+            // Check for ties
+            const teamsAtRank = rankings.filter((r) => r.rank === targetRank);
+            if (teamsAtRank.length > 1) continue;
+
+            // Wrong choices: ranked lower, >2 away from target
+            wrongPool = rankings.filter(
+              (r) => r.rank > targetRank && Math.abs(r.rank - targetRank) > 2
+            );
+          }
+
           if (wrongPool.length < 2) continue;
 
           const shuffledWrong = shuffleArray(wrongPool);
@@ -153,6 +186,7 @@ export function useGameEngine() {
               ordinal: ORDINAL[targetRank] || `#${targetRank}`,
               correctTeamId: correctTeam.team_id,
               choices,
+              mode: activeMode,
             });
             setLoading(false);
           }
@@ -174,7 +208,7 @@ export function useGameEngine() {
   // Generate initial question when categories load
   useEffect(() => {
     if (categories && categories.length > 0 && gameState === "playing" && !currentQuestion) {
-      generateQuestion(0);
+      generateQuestion(0, activeModeRef.current);
     }
   }, [categories, gameState, currentQuestion, generateQuestion]);
 
@@ -191,13 +225,10 @@ export function useGameEngine() {
 
         if (newScore > highScore) {
           setHighScore(newScore);
-          saveHighScore(newScore);
+          saveHighScore(activeModeRef.current, newScore);
         }
-
-        // No auto-advance on correct — user clicks "Next"
       } else {
         setGameState("wrong");
-        // Longer delay then show game over
         autoAdvanceTimer.current = setTimeout(() => {
           if (mountedRef.current) {
             setGameState("ended");
@@ -208,13 +239,20 @@ export function useGameEngine() {
     [gameState, currentQuestion, score, highScore, questionNumber, generateQuestion]
   );
 
-  const startGame = useCallback(() => {
-    setScore(0);
-    setQuestionNumber(0);
-    setGameState("playing");
-    setCurrentQuestion(null);
-    setSelectedTeamId(null);
-  }, []);
+  const startGame = useCallback(
+    (mode) => {
+      const selected = mode || gameMode;
+      setGameMode(selected);
+      activeModeRef.current = selected;
+      setHighScore(getHighScore(selected));
+      setScore(0);
+      setQuestionNumber(0);
+      setGameState("playing");
+      setCurrentQuestion(null);
+      setSelectedTeamId(null);
+    },
+    [gameMode]
+  );
 
   const resetGame = useCallback(() => {
     if (autoAdvanceTimer.current) clearTimeout(autoAdvanceTimer.current);
@@ -223,7 +261,6 @@ export function useGameEngine() {
     setGameState("playing");
     setCurrentQuestion(null);
     setSelectedTeamId(null);
-    // generateQuestion will be triggered by the useEffect when currentQuestion becomes null
   }, []);
 
   const nextQuestion = useCallback(() => {
@@ -232,11 +269,13 @@ export function useGameEngine() {
     setQuestionNumber(nextQ);
     setGameState("playing");
     setSelectedTeamId(null);
-    generateQuestion(nextQ);
+    generateQuestion(nextQ, activeModeRef.current);
   }, [gameState, questionNumber, generateQuestion]);
 
   return {
     gameState,
+    gameMode,
+    setGameMode: handleSetGameMode,
     questionNumber,
     score,
     highScore,

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -36,7 +36,6 @@ export function GamePage() {
     submitAnswer,
     nextQuestion,
     startGame,
-    resetGame,
   } = useGameEngine();
 
   const { data: allTeams } = useAllTeams();
@@ -78,10 +77,18 @@ export function GamePage() {
               >
                 NBA Top Five In Guesser
               </h1>
-              <p className="text-base-content/70 mb-6 text-lg">
+              <p className="text-base-content/70 mb-2 text-lg">
                 Test your NBA knowledge! Guess which team is ranked in the top 5 for each stat
                 category. How long can you keep your streak going?
               </p>
+              <div className="text-base-content/50 text-sm mb-6 space-y-1">
+                <p>
+                  <strong>Classic</strong> — Is this team in the top 5?
+                </p>
+                <p>
+                  <strong>Challenge</strong> — Guess the exact rank
+                </p>
+              </div>
 
               {/* Logo marquee - 2 rows */}
               {logosRow1.length > 0 && (
@@ -113,9 +120,20 @@ export function GamePage() {
                 </div>
               )}
 
-              <button className="btn btn-primary btn-lg px-12 w-full" onClick={startGame}>
-                Play
-              </button>
+              <div className="flex flex-col gap-2 w-full">
+                <button
+                  className="btn btn-primary btn-lg w-full"
+                  onClick={() => startGame("classic")}
+                >
+                  Play Classic Mode
+                </button>
+                <button
+                  className="btn btn-secondary btn-lg w-full"
+                  onClick={() => startGame("challenge")}
+                >
+                  Play Challenge Mode
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -151,16 +169,25 @@ export function GamePage() {
             ) : (
               <p className="text-base-content/50 mb-4">Your High Score: {highScore}</p>
             )}
-            <div className="flex flex-col gap-2 w-full">
-              <button className="btn btn-primary" onClick={resetGame}>
-                Play Again
-              </button>
-              <Link to="/" className="btn btn-outline">
-                View all Rankings
-              </Link>
-              <Link to="/teams" className="btn btn-outline">
-                View by Teams
-              </Link>
+            <div className="flex flex-col w-full">
+              <div className="divider text-sm">Try again</div>
+              <div className="flex flex-col gap-2">
+                <button className="btn btn-primary" onClick={() => startGame("classic")}>
+                  Play Classic Mode
+                </button>
+                <button className="btn btn-secondary" onClick={() => startGame("challenge")}>
+                  Play Challenge Mode
+                </button>
+              </div>
+              <div className="divider text-sm">View more</div>
+              <div className="flex flex-col gap-2">
+                <Link to="/" className="btn btn-outline">
+                  View all Rankings
+                </Link>
+                <Link to="/teams" className="btn btn-outline">
+                  View by Teams
+                </Link>
+              </div>
             </div>
           </div>
         </div>
@@ -203,8 +230,18 @@ export function GamePage() {
         <div className="card bg-base-200 shadow-xl">
           <div className="card-body">
             <h2 className="text-xl text-center mb-6 font-bold">
-              Which team is ranked <span className="text-amber-500">{currentQuestion.ordinal}</span>{" "}
-              in {currentQuestion.label}?
+              {currentQuestion.mode === "classic" ? (
+                <>
+                  Which team is in the <span className="text-amber-500">top 5</span> for{" "}
+                  {currentQuestion.label}?
+                </>
+              ) : (
+                <>
+                  Which team is ranked{" "}
+                  <span className="text-amber-500">{currentQuestion.ordinal}</span> in{" "}
+                  {currentQuestion.label}?
+                </>
+              )}
             </h2>
 
             {/* Choices */}

--- a/frontend/src/pages/__tests__/GamePage.test.jsx
+++ b/frontend/src/pages/__tests__/GamePage.test.jsx
@@ -7,10 +7,10 @@ import { GamePage } from "../GamePage";
 const mockSubmitAnswer = vi.fn();
 const mockNextQuestion = vi.fn();
 const mockStartGame = vi.fn();
-const mockResetGame = vi.fn();
 
 let mockGameState = {
   gameState: "playing",
+  gameMode: "classic",
   questionNumber: 0,
   score: 0,
   highScore: 3,
@@ -20,7 +20,6 @@ let mockGameState = {
   submitAnswer: mockSubmitAnswer,
   nextQuestion: mockNextQuestion,
   startGame: mockStartGame,
-  resetGame: mockResetGame,
 };
 
 vi.mock("../../hooks/useGameEngine", () => ({
@@ -56,6 +55,7 @@ const SAMPLE_QUESTION = {
   rank: 1,
   ordinal: "1st",
   correctTeamId: 1610612738,
+  mode: "challenge",
   choices: [
     {
       team_id: 1610612738,
@@ -89,6 +89,7 @@ describe("GamePage", () => {
     vi.clearAllMocks();
     mockGameState = {
       gameState: "playing",
+      gameMode: "classic",
       questionNumber: 0,
       score: 0,
       highScore: 3,
@@ -98,7 +99,6 @@ describe("GamePage", () => {
       submitAnswer: mockSubmitAnswer,
       nextQuestion: mockNextQuestion,
       startGame: mockStartGame,
-      resetGame: mockResetGame,
     };
   });
 
@@ -256,7 +256,7 @@ describe("GamePage", () => {
     expect(screen.getByText("Your High Score: 5")).toBeDefined();
   });
 
-  it("should show Play Again button on game over", () => {
+  it("should show Classic and Challenge buttons on game over", () => {
     mockGameState.gameState = "ended";
     mockGameState.score = 3;
     mockGameState.highScore = 5;
@@ -267,10 +267,11 @@ describe("GamePage", () => {
       </MemoryRouter>
     );
 
-    const playAgainBtn = screen.getByRole("button", { name: /Play Again/ });
-    expect(playAgainBtn).toBeDefined();
-    fireEvent.click(playAgainBtn);
-    expect(mockResetGame).toHaveBeenCalled();
+    fireEvent.click(screen.getByText("Play Classic Mode"));
+    expect(mockStartGame).toHaveBeenCalledWith("classic");
+
+    fireEvent.click(screen.getByText("Play Challenge Mode"));
+    expect(mockStartGame).toHaveBeenCalledWith("challenge");
   });
 
   it("should have navigation links on game over", () => {
@@ -302,7 +303,7 @@ describe("GamePage", () => {
     expect(screen.getByText("1")).toBeDefined();
   });
 
-  it("should render intro screen with Play button", () => {
+  it("should render intro screen with Classic and Challenge buttons", () => {
     mockGameState.gameState = "intro";
 
     render(
@@ -313,9 +314,65 @@ describe("GamePage", () => {
 
     expect(screen.getByText("NBA Top Five In Guesser")).toBeDefined();
     expect(screen.getByText(/Test your NBA knowledge/)).toBeDefined();
-    const playBtn = screen.getByRole("button", { name: "Play" });
-    expect(playBtn).toBeDefined();
-    fireEvent.click(playBtn);
-    expect(mockStartGame).toHaveBeenCalled();
+    expect(screen.getByText(/Is this team in the top 5/)).toBeDefined();
+    expect(screen.getByText(/Guess the exact rank/)).toBeDefined();
+    expect(screen.getByText("Play Classic Mode")).toBeDefined();
+    expect(screen.getByText("Play Challenge Mode")).toBeDefined();
+  });
+
+  it("should start classic mode when Classic button is clicked", () => {
+    mockGameState.gameState = "intro";
+
+    render(
+      <MemoryRouter>
+        <GamePage />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByText("Play Classic Mode"));
+    expect(mockStartGame).toHaveBeenCalledWith("classic");
+  });
+
+  it("should start challenge mode when Challenge button is clicked", () => {
+    mockGameState.gameState = "intro";
+
+    render(
+      <MemoryRouter>
+        <GamePage />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByText("Play Challenge Mode"));
+    expect(mockStartGame).toHaveBeenCalledWith("challenge");
+  });
+
+  it("should show classic question text for classic mode", () => {
+    mockGameState.currentQuestion = {
+      ...SAMPLE_QUESTION,
+      mode: "classic",
+    };
+
+    render(
+      <MemoryRouter>
+        <GamePage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/Which team is in the/)).toBeDefined();
+    expect(screen.getByText("top 5")).toBeDefined();
+    expect(screen.getByText(/Points Per Game/)).toBeDefined();
+  });
+
+  it("should show challenge question text for challenge mode", () => {
+    mockGameState.currentQuestion = SAMPLE_QUESTION;
+
+    render(
+      <MemoryRouter>
+        <GamePage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/Which team is ranked/)).toBeDefined();
+    expect(screen.getByText("1st")).toBeDefined();
   });
 });

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
       "picomatch@4": ">=4.0.4",
       "yaml@2": ">=2.8.3",
       "path-to-regexp": ">=8.4.0",
-      "brace-expansion": ">=5.0.5"
+      "brace-expansion": ">=5.0.5",
+      "lodash": ">=4.18.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   yaml@2: '>=2.8.3'
   path-to-regexp: '>=8.4.0'
   brace-expansion: '>=5.0.5'
+  lodash: '>=4.18.0'
 
 importers:
 
@@ -2653,8 +2654,8 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
@@ -5687,7 +5688,7 @@ snapshots:
 
   express-validator@7.3.1:
     dependencies:
-      lodash: 4.17.23
+      lodash: 4.18.1
       validator: 13.15.26
 
   express@5.2.1:
@@ -6667,7 +6668,7 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   log-update@6.1.0:
     dependencies:


### PR DESCRIPTION
Split the game into two distinct modes with separate high scores:

- **Classic** — "Is this team in the top 5?" Pick the team that belongs in the top 5 for a stat category. Wrong choices are ranked outside top 7.
- **Challenge** — "Guess the exact rank." Pick the team at a specific ranking. Wrong choices are >2 ranks away from the correct answer.

## Changes
- `useGameEngine.js`: Added `gameMode` state, separate localStorage high score keys per mode, parameterized `generateQuestion` with mode-specific logic, `startGame` accepts mode parameter
- `GamePage.jsx`: Intro screen with mode descriptions + "Play Classic Mode" / "Play Challenge Mode" buttons; game over screen with "Try again" divider + both mode buttons + "View more" divider + nav links; Challenge button uses NBA red (`btn-secondary`)
- `GamePage.test.jsx`: Updated tests for new button text, mode selector behavior, removed unused `resetGame` references
- `game.spec.js`: Updated E2E tests for new button text and intro screen assertions
