### PR TITLE
Set trust proxy for Railway reverse proxy

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -10,6 +10,9 @@ const { apiLimiter } = require("./middleware/rateLimiter");
 
 const app = express();
 
+// Trust first proxy (Railway) so express-rate-limit reads real client IP
+app.set("trust proxy", 1);
+
 const allowedOrigins = [
   "http://localhost:3000",
   "http://localhost:3001",


### PR DESCRIPTION
Fix `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` crash on Railway deployment.

Railway runs behind a reverse proxy that sets `X-Forwarded-For`. Without `trust proxy`, `express-rate-limit` throws a `ValidationError` and the server crashes with `SIGTERM`.

## Changes
- `backend/src/app.js`: Added `app.set("trust proxy", 1)` to trust the first proxy hop
